### PR TITLE
feat: AsaPhotoFilter - 画像フィルターアプリを実装

### DIFF
--- a/Apps/AsaPhotoFilter/AsaPhotoFilter.xcodeproj/project.pbxproj
+++ b/Apps/AsaPhotoFilter/AsaPhotoFilter.xcodeproj/project.pbxproj
@@ -1,0 +1,512 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		0BB48978B6304A4F5A477375 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9AB7928F9BD1609F1DFDDC59 /* SwiftUI.framework */; };
+		52D37BD41E383D56BAB9044C /* Photos.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 705765086F6F66607E4E7EBD /* Photos.framework */; };
+		592C30BBB3A17D1E85466425 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A6DEEA6F9C7F7099A888B8FD /* Assets.xcassets */; };
+		5C9E93278237E37311A12C1D /* AsaButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E039984F1EBE6B524C219031 /* AsaButton.swift */; };
+		61E44D08ABFB570114DF340E /* AsaLaunchScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 138370A1E8274AD183CE46AF /* AsaLaunchScreen.swift */; };
+		8181440D288338D35C72DFC6 /* ImageFilterService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9608FD528C4B70DFC5DF4BDE /* ImageFilterService.swift */; };
+		8F9802A844DC75B8B54654C1 /* AsaPhotoFilterApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26220DDFDE52485A66E5488D /* AsaPhotoFilterApp.swift */; };
+		A4E8EF276572BC47DDA417D2 /* FilterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42EC0AC8B3FAC493C5593F57 /* FilterViewModel.swift */; };
+		B6674389565BA4145054C4B6 /* AsaCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84444CA05E588324E00EA2DC /* AsaCard.swift */; };
+		B846CC10E73AEEBECACE30A7 /* PhotosUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A4B0DD331E6A6B760562052 /* PhotosUI.framework */; };
+		BCBB2B0C37C3B274B47C70F5 /* CoreImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00BD524A81AA57DD0445A06B /* CoreImage.framework */; };
+		BE0AC4E92690BB51CB5B3DB7 /* FilterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499DC00545B1165933A74F19 /* FilterType.swift */; };
+		CCFECC1738780C3FEED8EBB8 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8AFD1EA0FBA815834533208 /* ContentView.swift */; };
+		CDFCA3D211E31B9EC3C21AC9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A297509D7D190BA15EA942E3 /* Assets.xcassets */; };
+		E1D8BEB5FE97964025A8A018 /* AsaPhotoFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2CCB81AB20D4ED5D27DEF8A /* AsaPhotoFilterTests.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		0433E6AAC6A7DE349D9FE27B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0AC45DAC6BA6435FAC9264D9 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 196580C16E4665595A0B708D;
+			remoteInfo = AsaPhotoFilter;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		00BD524A81AA57DD0445A06B /* CoreImage.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreImage.framework; path = System/Library/Frameworks/CoreImage.framework; sourceTree = SDKROOT; };
+		138370A1E8274AD183CE46AF /* AsaLaunchScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsaLaunchScreen.swift; sourceTree = "<group>"; };
+		16C222A6DDA92BBDD16DEC6E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		26220DDFDE52485A66E5488D /* AsaPhotoFilterApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsaPhotoFilterApp.swift; sourceTree = "<group>"; };
+		42EC0AC8B3FAC493C5593F57 /* FilterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterViewModel.swift; sourceTree = "<group>"; };
+		499DC00545B1165933A74F19 /* FilterType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterType.swift; sourceTree = "<group>"; };
+		6A4B0DD331E6A6B760562052 /* PhotosUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PhotosUI.framework; path = System/Library/Frameworks/PhotosUI.framework; sourceTree = SDKROOT; };
+		705765086F6F66607E4E7EBD /* Photos.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Photos.framework; path = System/Library/Frameworks/Photos.framework; sourceTree = SDKROOT; };
+		84444CA05E588324E00EA2DC /* AsaCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsaCard.swift; sourceTree = "<group>"; };
+		9608FD528C4B70DFC5DF4BDE /* ImageFilterService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFilterService.swift; sourceTree = "<group>"; };
+		9AB7928F9BD1609F1DFDDC59 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
+		A0FA95544274B0B8FB2B1961 /* AsaPhotoFilter.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = AsaPhotoFilter.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A297509D7D190BA15EA942E3 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		A6DEEA6F9C7F7099A888B8FD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		B2CCB81AB20D4ED5D27DEF8A /* AsaPhotoFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsaPhotoFilterTests.swift; sourceTree = "<group>"; };
+		B560F7A75E0DC4BF0AE792A5 /* AsaPhotoFilterTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = AsaPhotoFilterTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		C8AFD1EA0FBA815834533208 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		E039984F1EBE6B524C219031 /* AsaButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsaButton.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		2794AA6D00556F33BD4042CD /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0BB48978B6304A4F5A477375 /* SwiftUI.framework in Frameworks */,
+				BCBB2B0C37C3B274B47C70F5 /* CoreImage.framework in Frameworks */,
+				52D37BD41E383D56BAB9044C /* Photos.framework in Frameworks */,
+				B846CC10E73AEEBECACE30A7 /* PhotosUI.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		211BBD2C5EA83D0CF86D6568 /* AsaPhotoFilterTests */ = {
+			isa = PBXGroup;
+			children = (
+				B2CCB81AB20D4ED5D27DEF8A /* AsaPhotoFilterTests.swift */,
+			);
+			path = AsaPhotoFilterTests;
+			sourceTree = "<group>";
+		};
+		50EA360218A799E344EFE810 /* AsaPhotoFilter */ = {
+			isa = PBXGroup;
+			children = (
+				26220DDFDE52485A66E5488D /* AsaPhotoFilterApp.swift */,
+				A297509D7D190BA15EA942E3 /* Assets.xcassets */,
+				C8AFD1EA0FBA815834533208 /* ContentView.swift */,
+				499DC00545B1165933A74F19 /* FilterType.swift */,
+				42EC0AC8B3FAC493C5593F57 /* FilterViewModel.swift */,
+				9608FD528C4B70DFC5DF4BDE /* ImageFilterService.swift */,
+				16C222A6DDA92BBDD16DEC6E /* Info.plist */,
+			);
+			path = AsaPhotoFilter;
+			sourceTree = "<group>";
+		};
+		6EB2D30DE1FD0EAA60871F83 /* Shared */ = {
+			isa = PBXGroup;
+			children = (
+				E039984F1EBE6B524C219031 /* AsaButton.swift */,
+				84444CA05E588324E00EA2DC /* AsaCard.swift */,
+				138370A1E8274AD183CE46AF /* AsaLaunchScreen.swift */,
+				A6DEEA6F9C7F7099A888B8FD /* Assets.xcassets */,
+			);
+			path = Shared;
+			sourceTree = "<group>";
+		};
+		863E3F4591B60B1AF7252A71 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A0FA95544274B0B8FB2B1961 /* AsaPhotoFilter.app */,
+				B560F7A75E0DC4BF0AE792A5 /* AsaPhotoFilterTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		96DA73C9C0E091BCF3A3CFDC = {
+			isa = PBXGroup;
+			children = (
+				EFCAB6A126C7CD16A8C677F6 /* AsaApps */,
+				50EA360218A799E344EFE810 /* AsaPhotoFilter */,
+				211BBD2C5EA83D0CF86D6568 /* AsaPhotoFilterTests */,
+				F2C27B14C5BF8F5D0E6E2E84 /* Frameworks */,
+				863E3F4591B60B1AF7252A71 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		EFCAB6A126C7CD16A8C677F6 /* AsaApps */ = {
+			isa = PBXGroup;
+			children = (
+				6EB2D30DE1FD0EAA60871F83 /* Shared */,
+			);
+			name = AsaApps;
+			path = ../..;
+			sourceTree = "<group>";
+		};
+		F2C27B14C5BF8F5D0E6E2E84 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				00BD524A81AA57DD0445A06B /* CoreImage.framework */,
+				705765086F6F66607E4E7EBD /* Photos.framework */,
+				6A4B0DD331E6A6B760562052 /* PhotosUI.framework */,
+				9AB7928F9BD1609F1DFDDC59 /* SwiftUI.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		196580C16E4665595A0B708D /* AsaPhotoFilter */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 104B2635F460B9576FD48DD2 /* Build configuration list for PBXNativeTarget "AsaPhotoFilter" */;
+			buildPhases = (
+				30CF5ACE20B29E60133CC4C2 /* Sources */,
+				35D6A3349581DF9B3749AD0B /* Resources */,
+				2794AA6D00556F33BD4042CD /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = AsaPhotoFilter;
+			packageProductDependencies = (
+			);
+			productName = AsaPhotoFilter;
+			productReference = A0FA95544274B0B8FB2B1961 /* AsaPhotoFilter.app */;
+			productType = "com.apple.product-type.application";
+		};
+		8E072EF5A26570FECD6FB163 /* AsaPhotoFilterTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6B2B9AF8107632A9ACE6E73A /* Build configuration list for PBXNativeTarget "AsaPhotoFilterTests" */;
+			buildPhases = (
+				D4C79BD813558B30A568D713 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A45BDE9BE0E9E60AF34D6A53 /* PBXTargetDependency */,
+			);
+			name = AsaPhotoFilterTests;
+			packageProductDependencies = (
+			);
+			productName = AsaPhotoFilterTests;
+			productReference = B560F7A75E0DC4BF0AE792A5 /* AsaPhotoFilterTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		0AC45DAC6BA6435FAC9264D9 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = YES;
+				LastUpgradeCheck = 1430;
+				TargetAttributes = {
+					196580C16E4665595A0B708D = {
+						DevelopmentTeam = "";
+						ProvisioningStyle = Automatic;
+					};
+					8E072EF5A26570FECD6FB163 = {
+						DevelopmentTeam = "";
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = D2A1CFBA7FA20784963DD354 /* Build configuration list for PBXProject "AsaPhotoFilter" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				Base,
+				en,
+			);
+			mainGroup = 96DA73C9C0E091BCF3A3CFDC;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				196580C16E4665595A0B708D /* AsaPhotoFilter */,
+				8E072EF5A26570FECD6FB163 /* AsaPhotoFilterTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		35D6A3349581DF9B3749AD0B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CDFCA3D211E31B9EC3C21AC9 /* Assets.xcassets in Resources */,
+				592C30BBB3A17D1E85466425 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		30CF5ACE20B29E60133CC4C2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5C9E93278237E37311A12C1D /* AsaButton.swift in Sources */,
+				B6674389565BA4145054C4B6 /* AsaCard.swift in Sources */,
+				61E44D08ABFB570114DF340E /* AsaLaunchScreen.swift in Sources */,
+				8F9802A844DC75B8B54654C1 /* AsaPhotoFilterApp.swift in Sources */,
+				CCFECC1738780C3FEED8EBB8 /* ContentView.swift in Sources */,
+				BE0AC4E92690BB51CB5B3DB7 /* FilterType.swift in Sources */,
+				A4E8EF276572BC47DDA417D2 /* FilterViewModel.swift in Sources */,
+				8181440D288338D35C72DFC6 /* ImageFilterService.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D4C79BD813558B30A568D713 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E1D8BEB5FE97964025A8A018 /* AsaPhotoFilterTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		A45BDE9BE0E9E60AF34D6A53 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 196580C16E4665595A0B708D /* AsaPhotoFilter */;
+			targetProxy = 0433E6AAC6A7DE349D9FE27B /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		07D507B5F36A91B695B17EC8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.asapapa.apps.asaphotofilter.tests;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AsaPhotoFilter.app/AsaPhotoFilter";
+			};
+			name = Release;
+		};
+		149F84E4A84695A5E28C466F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		72F09A76D38E757D377136B1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.asapapa.apps.asaphotofilter.tests;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AsaPhotoFilter.app/AsaPhotoFilter";
+			};
+			name = Debug;
+		};
+		7A0B464DA60661F37214C683 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				INFOPLIST_FILE = AsaPhotoFilter/Info.plist;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				NSPhotoLibraryAddUsageDescription = "フィルター適用後の写真を保存するために写真ライブラリへの書き込み権限が必要です";
+				NSPhotoLibraryUsageDescription = "写真にフィルターを適用するために写真ライブラリへのアクセスが必要です";
+				PRODUCT_BUNDLE_IDENTIFIER = com.asapapa.apps.asaphotofilter;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		C88EBAFAC74582748F77AA5B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"DEBUG=1",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		E1433DC3A112AB13FFB2833F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				INFOPLIST_FILE = AsaPhotoFilter/Info.plist;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				NSPhotoLibraryAddUsageDescription = "フィルター適用後の写真を保存するために写真ライブラリへの書き込み権限が必要です";
+				NSPhotoLibraryUsageDescription = "写真にフィルターを適用するために写真ライブラリへのアクセスが必要です";
+				PRODUCT_BUNDLE_IDENTIFIER = com.asapapa.apps.asaphotofilter;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		104B2635F460B9576FD48DD2 /* Build configuration list for PBXNativeTarget "AsaPhotoFilter" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7A0B464DA60661F37214C683 /* Debug */,
+				E1433DC3A112AB13FFB2833F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		6B2B9AF8107632A9ACE6E73A /* Build configuration list for PBXNativeTarget "AsaPhotoFilterTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				72F09A76D38E757D377136B1 /* Debug */,
+				07D507B5F36A91B695B17EC8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		D2A1CFBA7FA20784963DD354 /* Build configuration list for PBXProject "AsaPhotoFilter" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C88EBAFAC74582748F77AA5B /* Debug */,
+				149F84E4A84695A5E28C466F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 0AC45DAC6BA6435FAC9264D9 /* Project object */;
+}

--- a/Apps/AsaPhotoFilter/AsaPhotoFilter.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Apps/AsaPhotoFilter/AsaPhotoFilter.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Apps/AsaPhotoFilter/AsaPhotoFilter/AsaPhotoFilterApp.swift
+++ b/Apps/AsaPhotoFilter/AsaPhotoFilter/AsaPhotoFilterApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct AsaPhotoFilterApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/Apps/AsaPhotoFilter/AsaPhotoFilter/Assets.xcassets/Contents.json
+++ b/Apps/AsaPhotoFilter/AsaPhotoFilter/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Apps/AsaPhotoFilter/AsaPhotoFilter/ContentView.swift
+++ b/Apps/AsaPhotoFilter/AsaPhotoFilter/ContentView.swift
@@ -1,0 +1,206 @@
+import SwiftUI
+import PhotosUI
+
+struct ContentView: View {
+    @State private var viewModel = FilterViewModel()
+    @State private var showingPhotoPicker = false
+    
+    var body: some View {
+        NavigationView {
+            ZStack {
+                // 背景グラデーション
+                LinearGradient(
+                    colors: [Color("AsaSoftCream"), Color("AsaMutedSage")],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+                .ignoresSafeArea()
+                
+                ScrollView {
+                    VStack(spacing: 20) {
+                        // ヘッダー
+                        headerSection
+                        
+                        // 画像表示エリア
+                        imageDisplaySection
+                        
+                        // フィルター選択
+                        filterSelectionSection
+                        
+                        // 強度調整（セピア用）
+                        if viewModel.selectedFilter.supportsIntensity {
+                            intensitySection
+                        }
+                        
+                        // ボタンエリア
+                        buttonsSection
+                        
+                        Spacer(minLength: 20)
+                    }
+                    .padding(.horizontal, 20)
+                }
+            }
+            .navigationBarHidden(true)
+        }
+        .photosPicker(
+            isPresented: $showingPhotoPicker,
+            selection: $viewModel.selectedPhotoItem
+        )
+        .onChange(of: viewModel.selectedPhotoItem) { _, _ in
+            Task {
+                await viewModel.loadImageFromPhotoItem()
+            }
+        }
+        .alert("保存結果", isPresented: $viewModel.showingSaveAlert) {
+            Button("OK") {}
+        } message: {
+            Text(viewModel.saveMessage)
+        }
+    }
+    
+    private var headerSection: some View {
+        VStack(spacing: 8) {
+            Image("AsaPapaLabLogo")
+                .resizable()
+                .scaledToFit()
+                .frame(width: 80, height: 80)
+                .shadow(radius: 2)
+            
+            Text("アサパパの写真フィルター")
+                .font(.title2.weight(.medium))
+                .foregroundColor(Color("AsaCoffeeBrown"))
+        }
+        .padding(.top, 16)
+    }
+    
+    private var imageDisplaySection: some View {
+        AsaCard {
+            VStack {
+                if viewModel.isProcessing {
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 15)
+                            .fill(Color("AsaSoftCream").opacity(0.3))
+                            .frame(width: 280, height: 280)
+                        
+                        ProgressView("処理中...")
+                            .progressViewStyle(CircularProgressViewStyle(tint: Color("AsaCoffeeBrown")))
+                            .scaleEffect(1.2)
+                    }
+                } else if let displayImage = viewModel.filteredImage ?? viewModel.originalImage {
+                    Image(uiImage: displayImage)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(maxWidth: 280, maxHeight: 280)
+                        .cornerRadius(15)
+                        .shadow(radius: 3)
+                } else {
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 15)
+                            .fill(Color("AsaSoftCream").opacity(0.3))
+                            .frame(width: 280, height: 280)
+                        
+                        VStack(spacing: 12) {
+                            Image(systemName: "photo.badge.plus")
+                                .font(.system(size: 48))
+                                .foregroundColor(Color("AsaMutedSage"))
+                            
+                            Text("写真を選択してください")
+                                .font(.body.weight(.medium))
+                                .foregroundColor(Color("AsaMutedSage"))
+                        }
+                    }
+                }
+            }
+            .padding()
+        }
+    }
+    
+    private var filterSelectionSection: some View {
+        AsaCard {
+            VStack(spacing: 16) {
+                Text("フィルター選択")
+                    .font(.headline.weight(.medium))
+                    .foregroundColor(Color("AsaCoffeeBrown"))
+                
+                Picker("フィルター", selection: $viewModel.selectedFilter) {
+                    ForEach(FilterType.allCases, id: \.self) { filter in
+                        Text(filter.displayName)
+                            .tag(filter)
+                    }
+                }
+                .pickerStyle(MenuPickerStyle())
+                .onChange(of: viewModel.selectedFilter) { _, newValue in
+                    viewModel.updateFilter(newValue)
+                }
+                
+                if viewModel.selectedFilter != .none {
+                    Text(viewModel.selectedFilter.description)
+                        .font(.caption)
+                        .foregroundColor(Color("AsaMutedSage"))
+                        .multilineTextAlignment(.center)
+                }
+            }
+            .padding()
+        }
+    }
+    
+    private var intensitySection: some View {
+        AsaCard {
+            VStack(spacing: 12) {
+                Text("フィルター強度")
+                    .font(.subheadline.weight(.medium))
+                    .foregroundColor(Color("AsaCoffeeBrown"))
+                
+                Slider(
+                    value: $viewModel.filterIntensity,
+                    in: 0...1,
+                    step: 0.1
+                ) {
+                    Text("強度")
+                } minimumValueLabel: {
+                    Text("弱")
+                        .font(.caption)
+                        .foregroundColor(Color("AsaMutedSage"))
+                } maximumValueLabel: {
+                    Text("強")
+                        .font(.caption)
+                        .foregroundColor(Color("AsaMutedSage"))
+                }
+                .tint(Color("AsaCoffeeBrown"))
+                .onChange(of: viewModel.filterIntensity) { _, newValue in
+                    viewModel.updateIntensity(newValue)
+                }
+                
+                Text("\(Int(viewModel.filterIntensity * 100))%")
+                    .font(.caption.weight(.medium))
+                    .foregroundColor(Color("AsaCoffeeBrown"))
+            }
+            .padding()
+        }
+    }
+    
+    private var buttonsSection: some View {
+        VStack(spacing: 12) {
+            AsaButton(title: "写真を選択") {
+                showingPhotoPicker = true
+            }
+            .disabled(viewModel.isProcessing)
+            
+            HStack(spacing: 16) {
+                AsaButton(title: "保存", action: {
+                    viewModel.saveToPhotoLibrary()
+                }, color: Color("AsaMutedSage"))
+                .disabled(viewModel.originalImage == nil || viewModel.isProcessing)
+                
+                AsaButton(title: "リセット", action: {
+                    viewModel.resetToOriginal()
+                }, color: Color("AsaMocha"))
+                .disabled(viewModel.originalImage == nil || viewModel.isProcessing)
+            }
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/Apps/AsaPhotoFilter/AsaPhotoFilter/FilterType.swift
+++ b/Apps/AsaPhotoFilter/AsaPhotoFilter/FilterType.swift
@@ -1,0 +1,64 @@
+import Foundation
+import CoreImage
+
+enum FilterType: String, CaseIterable {
+    case none = "none"
+    case sepia = "CISepiaTone" 
+    case noir = "CIPhotoEffectNoir"
+    case vintage = "CIPhotoEffectInstant"
+    case vivid = "CIPhotoEffectVivid"
+    case dramatic = "CIPhotoEffectDramatic"
+    case mono = "CIPhotoEffectMono"
+    case tonal = "CIPhotoEffectTonal"
+    
+    var displayName: String {
+        switch self {
+        case .none:
+            return "フィルターなし"
+        case .sepia:
+            return "セピア"
+        case .noir:
+            return "ノワール"
+        case .vintage:
+            return "ビンテージ"
+        case .vivid:
+            return "鮮やか"
+        case .dramatic:
+            return "ドラマチック"
+        case .mono:
+            return "モノクロ"
+        case .tonal:
+            return "トーン調整"
+        }
+    }
+    
+    var description: String {
+        switch self {
+        case .none:
+            return "元の画像のまま"
+        case .sepia:
+            return "温かみのあるセピア調"
+        case .noir:
+            return "クラシックな白黒"
+        case .vintage:
+            return "レトロなインスタント風"
+        case .vivid:
+            return "色鮮やかな仕上がり"
+        case .dramatic:
+            return "コントラストの強い印象的な仕上がり"
+        case .mono:
+            return "シンプルなモノクロ"
+        case .tonal:
+            return "色調を調整したソフトな仕上がり"
+        }
+    }
+    
+    var supportsIntensity: Bool {
+        switch self {
+        case .sepia:
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/Apps/AsaPhotoFilter/AsaPhotoFilter/FilterViewModel.swift
+++ b/Apps/AsaPhotoFilter/AsaPhotoFilter/FilterViewModel.swift
@@ -1,0 +1,134 @@
+import SwiftUI
+import PhotosUI
+import Photos
+
+@Observable
+class FilterViewModel {
+    var selectedPhotoItem: PhotosPickerItem?
+    var originalImage: UIImage?
+    var filteredImage: UIImage?
+    var selectedFilter: FilterType = .none
+    var filterIntensity: Double = 1.0
+    var isProcessing = false
+    var showingSaveAlert = false
+    var saveMessage = ""
+    
+    private let filterService = ImageFilterService()
+    
+    init() {
+        loadSettings()
+    }
+    
+    func loadImageFromPhotoItem() async {
+        guard let selectedPhotoItem else { return }
+        
+        isProcessing = true
+        
+        do {
+            if let imageData = try await selectedPhotoItem.loadTransferable(type: Data.self),
+               let image = UIImage(data: imageData) {
+                
+                await MainActor.run {
+                    self.originalImage = image
+                    self.applyCurrentFilter()
+                }
+            }
+        } catch {
+            print("画像の読み込みに失敗しました: \(error)")
+        }
+        
+        isProcessing = false
+    }
+    
+    func applyCurrentFilter() {
+        guard let originalImage else { return }
+        
+        isProcessing = true
+        
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let self = self else { return }
+            
+            let intensity = self.selectedFilter.supportsIntensity ? self.filterIntensity : 1.0
+            let result = self.filterService.applyFilter(self.selectedFilter, to: originalImage, intensity: intensity)
+            
+            DispatchQueue.main.async {
+                self.filteredImage = result
+                self.isProcessing = false
+            }
+        }
+    }
+    
+    func updateFilter(_ newFilter: FilterType) {
+        selectedFilter = newFilter
+        saveSettings()
+        applyCurrentFilter()
+    }
+    
+    func updateIntensity(_ newIntensity: Double) {
+        filterIntensity = newIntensity
+        saveSettings()
+        applyCurrentFilter()
+    }
+    
+    func saveToPhotoLibrary() {
+        guard let imageToSave = filteredImage ?? originalImage else {
+            saveMessage = "保存する画像がありません"
+            showingSaveAlert = true
+            return
+        }
+        
+        PHPhotoLibrary.requestAuthorization(for: .addOnly) { [weak self] status in
+            DispatchQueue.main.async {
+                switch status {
+                case .authorized, .limited:
+                    self?.performSave(imageToSave)
+                case .denied, .restricted:
+                    self?.saveMessage = "写真ライブラリへのアクセス許可が必要です"
+                    self?.showingSaveAlert = true
+                case .notDetermined:
+                    self?.saveMessage = "写真ライブラリへのアクセス許可を確認してください"
+                    self?.showingSaveAlert = true
+                @unknown default:
+                    self?.saveMessage = "不明なエラーが発生しました"
+                    self?.showingSaveAlert = true
+                }
+            }
+        }
+    }
+    
+    private func performSave(_ image: UIImage) {
+        PHPhotoLibrary.shared().performChanges({
+            PHAssetChangeRequest.creationRequestForAsset(from: image)
+        }) { [weak self] success, error in
+            DispatchQueue.main.async {
+                if success {
+                    self?.saveMessage = "写真ライブラリに保存しました！"
+                } else {
+                    self?.saveMessage = "保存に失敗しました: \(error?.localizedDescription ?? "不明なエラー")"
+                }
+                self?.showingSaveAlert = true
+            }
+        }
+    }
+    
+    func resetToOriginal() {
+        selectedFilter = .none
+        filterIntensity = 1.0
+        filteredImage = originalImage
+        saveSettings()
+    }
+    
+    private func saveSettings() {
+        UserDefaults.standard.set(selectedFilter.rawValue, forKey: "selectedFilter")
+        UserDefaults.standard.set(filterIntensity, forKey: "filterIntensity")
+    }
+    
+    private func loadSettings() {
+        if let filterRawValue = UserDefaults.standard.object(forKey: "selectedFilter") as? String,
+           let savedFilter = FilterType(rawValue: filterRawValue) {
+            selectedFilter = savedFilter
+        }
+        
+        filterIntensity = UserDefaults.standard.object(forKey: "filterIntensity") as? Double ?? 1.0
+    }
+}

--- a/Apps/AsaPhotoFilter/AsaPhotoFilter/ImageFilterService.swift
+++ b/Apps/AsaPhotoFilter/AsaPhotoFilter/ImageFilterService.swift
@@ -1,0 +1,87 @@
+import UIKit
+import CoreImage
+import CoreImage.CIFilterBuiltins
+
+class ImageFilterService {
+    private let context = CIContext()
+    
+    func applyFilter(_ filterType: FilterType, to image: UIImage, intensity: Double = 1.0) -> UIImage? {
+        guard let inputImage = CIImage(image: image) else {
+            return nil
+        }
+        
+        let filteredImage: CIImage?
+        
+        switch filterType {
+        case .none:
+            filteredImage = inputImage
+        case .sepia:
+            filteredImage = applySepia(to: inputImage, intensity: intensity)
+        case .noir:
+            filteredImage = applyPhotoEffect(to: inputImage, filterName: "CIPhotoEffectNoir")
+        case .vintage:
+            filteredImage = applyPhotoEffect(to: inputImage, filterName: "CIPhotoEffectInstant")
+        case .vivid:
+            filteredImage = applyPhotoEffect(to: inputImage, filterName: "CIPhotoEffectVivid")
+        case .dramatic:
+            filteredImage = applyPhotoEffect(to: inputImage, filterName: "CIPhotoEffectDramatic")
+        case .mono:
+            filteredImage = applyPhotoEffect(to: inputImage, filterName: "CIPhotoEffectMono")
+        case .tonal:
+            filteredImage = applyPhotoEffect(to: inputImage, filterName: "CIPhotoEffectTonal")
+        }
+        
+        guard let outputImage = filteredImage else {
+            return nil
+        }
+        
+        guard let cgImage = context.createCGImage(outputImage, from: outputImage.extent) else {
+            return nil
+        }
+        
+        return UIImage(cgImage: cgImage)
+    }
+    
+    private func applySepia(to inputImage: CIImage, intensity: Double) -> CIImage? {
+        let filter = CIFilter(name: "CISepiaTone")
+        filter?.setValue(inputImage, forKey: kCIInputImageKey)
+        filter?.setValue(intensity, forKey: kCIInputIntensityKey)
+        return filter?.outputImage
+    }
+    
+    private func applyPhotoEffect(to inputImage: CIImage, filterName: String) -> CIImage? {
+        let filter = CIFilter(name: filterName)
+        filter?.setValue(inputImage, forKey: kCIInputImageKey)
+        return filter?.outputImage
+    }
+}
+
+extension ImageFilterService {
+    func createFilterPreview(_ filterType: FilterType, sourceImage: UIImage, previewSize: CGSize = CGSize(width: 150, height: 150)) -> UIImage? {
+        let resizedImage = resizeImageForPreview(sourceImage, targetSize: previewSize)
+        return applyFilter(filterType, to: resizedImage, intensity: 1.0)
+    }
+    
+    private func resizeImageForPreview(_ image: UIImage, targetSize: CGSize) -> UIImage {
+        let size = image.size
+        
+        let widthRatio  = targetSize.width  / size.width
+        let heightRatio = targetSize.height / size.height
+        
+        var newSize: CGSize
+        if widthRatio > heightRatio {
+            newSize = CGSize(width: size.width * heightRatio, height: size.height * heightRatio)
+        } else {
+            newSize = CGSize(width: size.width * widthRatio, height: size.height * widthRatio)
+        }
+        
+        let rect = CGRect(origin: .zero, size: newSize)
+        
+        UIGraphicsBeginImageContextWithOptions(newSize, false, 1.0)
+        image.draw(in: rect)
+        let newImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        
+        return newImage ?? image
+    }
+}

--- a/Apps/AsaPhotoFilter/AsaPhotoFilter/Info.plist
+++ b/Apps/AsaPhotoFilter/AsaPhotoFilter/Info.plist
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>写真にフィルターを適用するために写真ライブラリへのアクセスが必要です</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>フィルター適用後の写真を保存するために写真ライブラリへの書き込み権限が必要です</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Apps/AsaPhotoFilter/AsaPhotoFilterTests/AsaPhotoFilterTests.swift
+++ b/Apps/AsaPhotoFilter/AsaPhotoFilterTests/AsaPhotoFilterTests.swift
@@ -1,0 +1,42 @@
+import Testing
+@testable import AsaPhotoFilter
+
+struct AsaPhotoFilterTests {
+
+    @Test("フィルタータイプの表示名が正しく設定されている")
+    func testFilterTypeDisplayNames() async throws {
+        #expect(FilterType.none.displayName == "フィルターなし")
+        #expect(FilterType.sepia.displayName == "セピア")
+        #expect(FilterType.noir.displayName == "ノワール")
+        #expect(FilterType.vintage.displayName == "ビンテージ")
+        #expect(FilterType.vivid.displayName == "鮮やか")
+        #expect(FilterType.dramatic.displayName == "ドラマチック")
+        #expect(FilterType.mono.displayName == "モノクロ")
+        #expect(FilterType.tonal.displayName == "トーン調整")
+    }
+    
+    @Test("セピアフィルターは強度調整をサポートする")
+    func testSepiaSupportsIntensity() async throws {
+        #expect(FilterType.sepia.supportsIntensity == true)
+        #expect(FilterType.noir.supportsIntensity == false)
+        #expect(FilterType.none.supportsIntensity == false)
+    }
+    
+    @Test("ImageFilterServiceが初期化される")
+    func testImageFilterServiceInitialization() async throws {
+        let service = ImageFilterService()
+        // ImageFilterServiceが正常に初期化されることを確認
+        #expect(service != nil)
+    }
+    
+    @Test("FilterViewModelが初期状態で正しく設定される")
+    func testFilterViewModelInitialState() async throws {
+        let viewModel = FilterViewModel()
+        
+        #expect(viewModel.selectedFilter == .none)
+        #expect(viewModel.filterIntensity == 1.0)
+        #expect(viewModel.originalImage == nil)
+        #expect(viewModel.filteredImage == nil)
+        #expect(viewModel.isProcessing == false)
+    }
+}

--- a/Apps/AsaPhotoFilter/project.yml
+++ b/Apps/AsaPhotoFilter/project.yml
@@ -1,0 +1,49 @@
+name: AsaPhotoFilter
+options:
+  bundleIdPrefix: com.asapapa.apps
+  deploymentTarget:
+    iOS: "17.0"
+  createIntermediateGroups: true
+  generateEmptyDirectories: true
+
+settings:
+  MARKETING_VERSION: "1.0"
+  CURRENT_PROJECT_VERSION: "1"
+  DEVELOPMENT_TEAM: ""
+  CODE_SIGN_STYLE: Automatic
+
+targets:
+  AsaPhotoFilter:
+    type: application
+    platform: iOS
+    sources: 
+      - AsaPhotoFilter
+      - ../../Shared
+    resources:
+      - AsaPhotoFilter/Assets.xcassets
+      - ../../Shared/Assets.xcassets
+    settings:
+      PRODUCT_BUNDLE_IDENTIFIER: com.asapapa.apps.asaphotofilter
+      INFOPLIST_FILE: AsaPhotoFilter/Info.plist
+      INFOPLIST_KEY_UIApplicationSceneManifest_Generation: true
+      INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents: true
+      INFOPLIST_KEY_UILaunchScreen_Generation: true
+      INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone: "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
+      INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad: "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
+      NSPhotoLibraryUsageDescription: "写真にフィルターを適用するために写真ライブラリへのアクセスが必要です"
+      NSPhotoLibraryAddUsageDescription: "フィルター適用後の写真を保存するために写真ライブラリへの書き込み権限が必要です"
+    dependencies:
+      - sdk: SwiftUI.framework
+      - sdk: CoreImage.framework
+      - sdk: Photos.framework
+      - sdk: PhotosUI.framework
+
+  AsaPhotoFilterTests:
+    type: bundle.unit-test
+    platform: iOS
+    sources: AsaPhotoFilterTests
+    settings:
+      PRODUCT_BUNDLE_IDENTIFIER: com.asapapa.apps.asaphotofilter.tests
+      GENERATE_INFOPLIST_FILE: YES
+    dependencies:
+      - target: AsaPhotoFilter


### PR DESCRIPTION
## 📱 概要
AsaPhotoFilter: 画像にフィルターをかけるSwiftUIアプリを実装しました。
48番目のAsaAppsコレクションアプリです。

## ✨ 主な機能
- **8種類の画像フィルター**: セピア、ノワール、ビンテージ、鮮やか、ドラマチック、モノクロ、トーン調整
- **リアルタイムプレビュー**: フィルター適用結果を即座に確認
- **強度調整機能**: セピアフィルターの強度を0-100%で調整可能
- **写真選択機能**: PhotosPickerによるモダンな写真選択UI
- **保存機能**: フィルター適用後の画像を写真ライブラリに保存

## 🛠️ 技術仕様
- **プロジェクト管理**: xcodegenによるYAML設定ファイル
- **画像処理**: Core Imageフレームワーク (CIFilter使用)
- **状態管理**: @Observableパターン
- **UI**: SwiftUI + 共有コンポーネント (AsaButton/AsaCard)
- **デザイン**: ブランドカラー統一デザイン
- **テスト**: Swift Testingによる単体テスト
- **最小iOS**: 17.0以上

## 📂 実装内容
- `FilterType.swift`: フィルター種類の定義とメタデータ
- `ImageFilterService.swift`: Core Imageを使用したフィルター処理サービス
- `FilterViewModel.swift`: @Observable状態管理とユーザー操作処理
- `ContentView.swift`: メインUI (フィルター選択、プレビュー、操作)
- `AsaPhotoFilterApp.swift`: アプリエントリーポイント
- `AsaPhotoFilterTests.swift`: Swift Testing単体テスト

## 🎨 ブランド統一
- AsaCoffeeBrown、AsaSoftCream等の統一カラーパレット
- AsaButton/AsaCardコンポーネントの再利用
- 温かみのあるグラデーション背景

## ✅ テスト計画
- [x] ビルドテスト成功
- [x] Swift Testing単体テスト実行成功
- [x] フィルター種類の表示名テスト
- [x] フィルター強度サポートテスト
- [x] ViewModelの初期状態テスト

🤖 Generated with [Claude Code](https://claude.ai/code)