### PR TITLE
feat: AsaMindMapマインドマップ作成アプリを実装

### DIFF
--- a/Apps/AsaMindMap/AsaMindMap.xcodeproj/project.pbxproj
+++ b/Apps/AsaMindMap/AsaMindMap.xcodeproj/project.pbxproj
@@ -1,0 +1,608 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		09EA593C3911A71B74DAA3F8 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F9A2FDD4D486B5E101BA414C /* SwiftUI.framework */; };
+		0B3F24FC6F5EDED44488EB30 /* ConnectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BC486CBFE70F88CC57F210 /* ConnectionView.swift */; };
+		2D3240F9A94C46FF15F8983F /* AsaMindMapApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 950B5D4F8B08FF8B2517DE78 /* AsaMindMapApp.swift */; };
+		32155937446800223FD03A65 /* MindMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCD7DB46157222EA513D8C8E /* MindMap.swift */; };
+		4FD18A50187016FDEAC7AAE8 /* MindMapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A44DEE6A17D5428941C5BE1 /* MindMapViewModel.swift */; };
+		7EE714181591F85AB5DEB074 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6142038FAC056FF66E30BD9F /* Assets.xcassets */; };
+		8705FF9A05C87D10D347C7EC /* AsaLaunchScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD855B73F74B72D25D9F21BA /* AsaLaunchScreen.swift */; };
+		8919432D2165C860FC6315B1 /* MindMapCanvasView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA3C5AF7A8FE9D1CD0D1C2DE /* MindMapCanvasView.swift */; };
+		963D017935F64B54BEF31061 /* NodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4832A1A3207F2D6E9E663439 /* NodeView.swift */; };
+		B77D54C1B38D2EAACE37C96F /* MindMapConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB20F8368449C6DE8738DEA6 /* MindMapConnection.swift */; };
+		BE9EB63128556D09099FB454 /* MindMapNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3639E0607B3192D81C30337 /* MindMapNode.swift */; };
+		C92409DC17E4AF4130E3C237 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C0ED9416DB2650C1C6DDC1C4 /* Assets.xcassets */; };
+		E31993BDC3CDB7FA9D4437D3 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DAD3B18580818AAE7D8BBFA4 /* Foundation.framework */; };
+		F348F0C082DA7FA541048667 /* AsaButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C84DC38334CC098776E53F6D /* AsaButton.swift */; };
+		F906075E3E9AA48BCE9E4BD6 /* AsaCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFC58E83F3FFAFFAF6F28D31 /* AsaCard.swift */; };
+		F9812B83839C745151730E08 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2868FB94A22BD539D378602C /* ContentView.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		5E8F269427F1D8CBFCECFF35 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CACFEC836639DE9FCAEE7FEF /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9B8472C997EB8A6AD65A98BA;
+			remoteInfo = AsaMindMap;
+		};
+		AE199945691FAED4116CDEDD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CACFEC836639DE9FCAEE7FEF /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9B8472C997EB8A6AD65A98BA;
+			remoteInfo = AsaMindMap;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		02BC486CBFE70F88CC57F210 /* ConnectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionView.swift; sourceTree = "<group>"; };
+		2868FB94A22BD539D378602C /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		2A44DEE6A17D5428941C5BE1 /* MindMapViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MindMapViewModel.swift; sourceTree = "<group>"; };
+		2F6AAACEFB6ABEA4B1307C4D /* AsaMindMapUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = AsaMindMapUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		4832A1A3207F2D6E9E663439 /* NodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeView.swift; sourceTree = "<group>"; };
+		6142038FAC056FF66E30BD9F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		762C0BEA69F77098D02C178D /* AsaMindMap.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = AsaMindMap.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		950B5D4F8B08FF8B2517DE78 /* AsaMindMapApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsaMindMapApp.swift; sourceTree = "<group>"; };
+		A3639E0607B3192D81C30337 /* MindMapNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MindMapNode.swift; sourceTree = "<group>"; };
+		AB20F8368449C6DE8738DEA6 /* MindMapConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MindMapConnection.swift; sourceTree = "<group>"; };
+		AFC58E83F3FFAFFAF6F28D31 /* AsaCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsaCard.swift; sourceTree = "<group>"; };
+		B57EE2D64CB9E6C270E18227 /* AsaMindMapTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = AsaMindMapTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		BCD7DB46157222EA513D8C8E /* MindMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MindMap.swift; sourceTree = "<group>"; };
+		C0ED9416DB2650C1C6DDC1C4 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		C84DC38334CC098776E53F6D /* AsaButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsaButton.swift; sourceTree = "<group>"; };
+		CA3C5AF7A8FE9D1CD0D1C2DE /* MindMapCanvasView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MindMapCanvasView.swift; sourceTree = "<group>"; };
+		CD855B73F74B72D25D9F21BA /* AsaLaunchScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsaLaunchScreen.swift; sourceTree = "<group>"; };
+		DAD3B18580818AAE7D8BBFA4 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		F9A2FDD4D486B5E101BA414C /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		57C8DCDEF858449177FDB073 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				09EA593C3911A71B74DAA3F8 /* SwiftUI.framework in Frameworks */,
+				E31993BDC3CDB7FA9D4437D3 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		05232EE8E5423B56161B37B3 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				762C0BEA69F77098D02C178D /* AsaMindMap.app */,
+				B57EE2D64CB9E6C270E18227 /* AsaMindMapTests.xctest */,
+				2F6AAACEFB6ABEA4B1307C4D /* AsaMindMapUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		0A56BB06F07356DBF2D9F9F5 /* AsaApps */ = {
+			isa = PBXGroup;
+			children = (
+				3E46C094918BB34B9388F4E2 /* Shared */,
+			);
+			name = AsaApps;
+			path = ../..;
+			sourceTree = "<group>";
+		};
+		3E46C094918BB34B9388F4E2 /* Shared */ = {
+			isa = PBXGroup;
+			children = (
+				C84DC38334CC098776E53F6D /* AsaButton.swift */,
+				AFC58E83F3FFAFFAF6F28D31 /* AsaCard.swift */,
+				CD855B73F74B72D25D9F21BA /* AsaLaunchScreen.swift */,
+				C0ED9416DB2650C1C6DDC1C4 /* Assets.xcassets */,
+			);
+			path = Shared;
+			sourceTree = "<group>";
+		};
+		5E428A8A904FDC1A8F4F39BC /* AsaMindMapTests */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = AsaMindMapTests;
+			sourceTree = "<group>";
+		};
+		6A945D72ADC6C1A4B7F4BC46 /* AsaMindMap */ = {
+			isa = PBXGroup;
+			children = (
+				950B5D4F8B08FF8B2517DE78 /* AsaMindMapApp.swift */,
+				6142038FAC056FF66E30BD9F /* Assets.xcassets */,
+				02BC486CBFE70F88CC57F210 /* ConnectionView.swift */,
+				2868FB94A22BD539D378602C /* ContentView.swift */,
+				BCD7DB46157222EA513D8C8E /* MindMap.swift */,
+				CA3C5AF7A8FE9D1CD0D1C2DE /* MindMapCanvasView.swift */,
+				AB20F8368449C6DE8738DEA6 /* MindMapConnection.swift */,
+				A3639E0607B3192D81C30337 /* MindMapNode.swift */,
+				2A44DEE6A17D5428941C5BE1 /* MindMapViewModel.swift */,
+				4832A1A3207F2D6E9E663439 /* NodeView.swift */,
+			);
+			path = AsaMindMap;
+			sourceTree = "<group>";
+		};
+		743C2B04DF856EC5D0216310 = {
+			isa = PBXGroup;
+			children = (
+				0A56BB06F07356DBF2D9F9F5 /* AsaApps */,
+				6A945D72ADC6C1A4B7F4BC46 /* AsaMindMap */,
+				5E428A8A904FDC1A8F4F39BC /* AsaMindMapTests */,
+				CE069F7BAB723A7EBC3C996C /* AsaMindMapUITests */,
+				AE319DBE6C3F63A75BC108D2 /* Frameworks */,
+				05232EE8E5423B56161B37B3 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		AE319DBE6C3F63A75BC108D2 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				DAD3B18580818AAE7D8BBFA4 /* Foundation.framework */,
+				F9A2FDD4D486B5E101BA414C /* SwiftUI.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		CE069F7BAB723A7EBC3C996C /* AsaMindMapUITests */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = AsaMindMapUITests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		1A8E74E83548407CC6971752 /* AsaMindMapTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E4562BC5ECA581B458093CB9 /* Build configuration list for PBXNativeTarget "AsaMindMapTests" */;
+			buildPhases = (
+				E522A8226C4DB0E6C0BE9906 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				6B35B17A58B6B0E909011DB0 /* PBXTargetDependency */,
+			);
+			name = AsaMindMapTests;
+			packageProductDependencies = (
+			);
+			productName = AsaMindMapTests;
+			productReference = B57EE2D64CB9E6C270E18227 /* AsaMindMapTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		9A85115D848E16924799B325 /* AsaMindMapUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2C96A452C45B1E0905C26B19 /* Build configuration list for PBXNativeTarget "AsaMindMapUITests" */;
+			buildPhases = (
+				9E82694DED57F115F9809CEA /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				831F242149C407690BECA935 /* PBXTargetDependency */,
+			);
+			name = AsaMindMapUITests;
+			packageProductDependencies = (
+			);
+			productName = AsaMindMapUITests;
+			productReference = 2F6AAACEFB6ABEA4B1307C4D /* AsaMindMapUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+		9B8472C997EB8A6AD65A98BA /* AsaMindMap */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2E2CF3AACE9F0004056ED814 /* Build configuration list for PBXNativeTarget "AsaMindMap" */;
+			buildPhases = (
+				7E6FA1F937E935995BA70044 /* Sources */,
+				91444EB8A2325C63AEEA608F /* Resources */,
+				57C8DCDEF858449177FDB073 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = AsaMindMap;
+			packageProductDependencies = (
+			);
+			productName = AsaMindMap;
+			productReference = 762C0BEA69F77098D02C178D /* AsaMindMap.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		CACFEC836639DE9FCAEE7FEF /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = YES;
+				LastUpgradeCheck = 1430;
+				TargetAttributes = {
+					1A8E74E83548407CC6971752 = {
+						DevelopmentTeam = "";
+						ProvisioningStyle = Automatic;
+					};
+					9A85115D848E16924799B325 = {
+						DevelopmentTeam = "";
+						ProvisioningStyle = Automatic;
+						TestTargetID = 9B8472C997EB8A6AD65A98BA;
+					};
+					9B8472C997EB8A6AD65A98BA = {
+						DevelopmentTeam = "";
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = 6EB151D403DDBC367B357B40 /* Build configuration list for PBXProject "AsaMindMap" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				Base,
+				en,
+			);
+			mainGroup = 743C2B04DF856EC5D0216310;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				9B8472C997EB8A6AD65A98BA /* AsaMindMap */,
+				1A8E74E83548407CC6971752 /* AsaMindMapTests */,
+				9A85115D848E16924799B325 /* AsaMindMapUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		91444EB8A2325C63AEEA608F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7EE714181591F85AB5DEB074 /* Assets.xcassets in Resources */,
+				C92409DC17E4AF4130E3C237 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		7E6FA1F937E935995BA70044 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F348F0C082DA7FA541048667 /* AsaButton.swift in Sources */,
+				F906075E3E9AA48BCE9E4BD6 /* AsaCard.swift in Sources */,
+				8705FF9A05C87D10D347C7EC /* AsaLaunchScreen.swift in Sources */,
+				2D3240F9A94C46FF15F8983F /* AsaMindMapApp.swift in Sources */,
+				0B3F24FC6F5EDED44488EB30 /* ConnectionView.swift in Sources */,
+				F9812B83839C745151730E08 /* ContentView.swift in Sources */,
+				32155937446800223FD03A65 /* MindMap.swift in Sources */,
+				8919432D2165C860FC6315B1 /* MindMapCanvasView.swift in Sources */,
+				B77D54C1B38D2EAACE37C96F /* MindMapConnection.swift in Sources */,
+				BE9EB63128556D09099FB454 /* MindMapNode.swift in Sources */,
+				4FD18A50187016FDEAC7AAE8 /* MindMapViewModel.swift in Sources */,
+				963D017935F64B54BEF31061 /* NodeView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9E82694DED57F115F9809CEA /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E522A8226C4DB0E6C0BE9906 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		6B35B17A58B6B0E909011DB0 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9B8472C997EB8A6AD65A98BA /* AsaMindMap */;
+			targetProxy = AE199945691FAED4116CDEDD /* PBXContainerItemProxy */;
+		};
+		831F242149C407690BECA935 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9B8472C997EB8A6AD65A98BA /* AsaMindMap */;
+			targetProxy = 5E8F269427F1D8CBFCECFF35 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		20CA4F715E76BC92A4012D43 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"DEBUG=1",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		403FA74F91865D09A2DA6F7E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		7C4BEA694066FB9A74F9FD1D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.asapapa.apps.asamindmap;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		A0B76741A5A855F73D6C5553 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.asapapa.apps.asamindmap.tests;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AsaMindMap.app/AsaMindMap";
+			};
+			name = Release;
+		};
+		AC022252C45DAC99A0BD7C9A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.asapapa.apps.asamindmap.ui-tests";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = AsaMindMap;
+			};
+			name = Debug;
+		};
+		E7EDFC041805F039DCE7A525 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.asapapa.apps.asamindmap.ui-tests";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = AsaMindMap;
+			};
+			name = Release;
+		};
+		F607716BDEE28C96B3990127 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.asapapa.apps.asamindmap;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		FE8FFC7C5802EE2CD01E677C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.asapapa.apps.asamindmap.tests;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AsaMindMap.app/AsaMindMap";
+			};
+			name = Debug;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		2C96A452C45B1E0905C26B19 /* Build configuration list for PBXNativeTarget "AsaMindMapUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AC022252C45DAC99A0BD7C9A /* Debug */,
+				E7EDFC041805F039DCE7A525 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		2E2CF3AACE9F0004056ED814 /* Build configuration list for PBXNativeTarget "AsaMindMap" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F607716BDEE28C96B3990127 /* Debug */,
+				7C4BEA694066FB9A74F9FD1D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		6EB151D403DDBC367B357B40 /* Build configuration list for PBXProject "AsaMindMap" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				20CA4F715E76BC92A4012D43 /* Debug */,
+				403FA74F91865D09A2DA6F7E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		E4562BC5ECA581B458093CB9 /* Build configuration list for PBXNativeTarget "AsaMindMapTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FE8FFC7C5802EE2CD01E677C /* Debug */,
+				A0B76741A5A855F73D6C5553 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = CACFEC836639DE9FCAEE7FEF /* Project object */;
+}

--- a/Apps/AsaMindMap/AsaMindMap.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Apps/AsaMindMap/AsaMindMap.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Apps/AsaMindMap/AsaMindMap/AsaMindMapApp.swift
+++ b/Apps/AsaMindMap/AsaMindMap/AsaMindMapApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct AsaMindMapApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/Apps/AsaMindMap/AsaMindMap/Assets.xcassets/Contents.json
+++ b/Apps/AsaMindMap/AsaMindMap/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Apps/AsaMindMap/AsaMindMap/ConnectionView.swift
+++ b/Apps/AsaMindMap/AsaMindMap/ConnectionView.swift
@@ -1,0 +1,273 @@
+import SwiftUI
+
+// MARK: - ConnectionView
+
+struct ConnectionView: View {
+    let viewModel: MindMapViewModel
+    let connection: MindMapConnection
+    let fromNode: MindMapNode
+    let toNode: MindMapNode
+    @State private var showDeleteButton = false
+    
+    var body: some View {
+        Canvas { context, size in
+            drawConnection(context: context, size: size)
+        }
+        .gesture(
+            TapGesture()
+                .onEnded {
+                    toggleDeleteButton()
+                }
+        )
+        .overlay(
+            deleteButton,
+            alignment: .center
+        )
+        .animation(.easeInOut(duration: 0.3), value: showDeleteButton)
+    }
+    
+    // MARK: - Connection Drawing
+    
+    private func drawConnection(context: GraphicsContext, size: CGSize) {
+        let fromPosition = viewModel.getDisplayPosition(for: fromNode.position)
+        let toPosition = viewModel.getDisplayPosition(for: toNode.position)
+        
+        // ノードの中心点を計算（ノードサイズを考慮）
+        let nodeRadius: CGFloat = 40
+        let adjustedFromPosition = adjustPosition(fromPosition, towards: toPosition, offset: nodeRadius)
+        let adjustedToPosition = adjustPosition(toPosition, towards: fromPosition, offset: nodeRadius)
+        
+        // ベジェ曲線のコントロールポイントを計算
+        let controlPoint1 = calculateControlPoint(from: adjustedFromPosition, to: adjustedToPosition, isFirst: true)
+        let controlPoint2 = calculateControlPoint(from: adjustedFromPosition, to: adjustedToPosition, isFirst: false)
+        
+        // パスを作成
+        var path = Path()
+        path.move(to: adjustedFromPosition)
+        path.addCurve(
+            to: adjustedToPosition,
+            control1: controlPoint1,
+            control2: controlPoint2
+        )
+        
+        // 線を描画
+        context.stroke(
+            path,
+            with: .color(connectionColor),
+            style: connection.lineStyle.strokeStyle
+        )
+        
+        // 矢印を描画
+        drawArrow(context: context, at: adjustedToPosition, angle: angleToTarget(from: controlPoint2, to: adjustedToPosition))
+    }
+    
+    // MARK: - Arrow Drawing
+    
+    private func drawArrow(context: GraphicsContext, at position: CGPoint, angle: Double) {
+        let arrowLength: CGFloat = 12
+        let arrowAngle: Double = .pi / 6 // 30度
+        
+        var arrowPath = Path()
+        
+        // 矢印の左の線
+        let leftPoint = CGPoint(
+            x: position.x - arrowLength * cos(angle - arrowAngle),
+            y: position.y - arrowLength * sin(angle - arrowAngle)
+        )
+        
+        // 矢印の右の線
+        let rightPoint = CGPoint(
+            x: position.x - arrowLength * cos(angle + arrowAngle),
+            y: position.y - arrowLength * sin(angle + arrowAngle)
+        )
+        
+        arrowPath.move(to: leftPoint)
+        arrowPath.addLine(to: position)
+        arrowPath.addLine(to: rightPoint)
+        
+        context.stroke(
+            arrowPath,
+            with: .color(connectionColor),
+            style: StrokeStyle(lineWidth: 2, lineCap: .round)
+        )
+    }
+    
+    // MARK: - Delete Button
+    
+    private var deleteButton: some View {
+        Group {
+            if showDeleteButton {
+                Button(action: deleteConnection) {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.title2)
+                        .foregroundColor(.red)
+                        .background(Circle().fill(Color.white))
+                        .shadow(radius: 2)
+                }
+                .position(midPoint)
+                .transition(.scale.combined(with: .opacity))
+            }
+        }
+    }
+    
+    // MARK: - Helper Methods
+    
+    private func adjustPosition(_ position: CGPoint, towards target: CGPoint, offset: CGFloat) -> CGPoint {
+        let dx = target.x - position.x
+        let dy = target.y - position.y
+        let distance = sqrt(dx * dx + dy * dy)
+        
+        guard distance > 0 else { return position }
+        
+        let ratio = offset / distance
+        return CGPoint(
+            x: position.x + dx * ratio,
+            y: position.y + dy * ratio
+        )
+    }
+    
+    private func calculateControlPoint(from: CGPoint, to: CGPoint, isFirst: Bool) -> CGPoint {
+        let midX = (from.x + to.x) / 2
+        let midY = (from.y + to.y) / 2
+        
+        let dx = to.x - from.x
+        let dy = to.y - from.y
+        let distance = sqrt(dx * dx + dy * dy)
+        
+        // 曲線の強度を距離に基づいて調整
+        let curveStrength = min(distance * 0.3, 100)
+        
+        // 垂直方向のオフセット
+        let offsetX = -dy / distance * curveStrength * (isFirst ? 0.5 : -0.5)
+        let offsetY = dx / distance * curveStrength * (isFirst ? 0.5 : -0.5)
+        
+        return CGPoint(
+            x: midX + offsetX,
+            y: midY + offsetY
+        )
+    }
+    
+    private func angleToTarget(from: CGPoint, to: CGPoint) -> Double {
+        let dx = to.x - from.x
+        let dy = to.y - from.y
+        return atan2(dy, dx)
+    }
+    
+    // MARK: - Computed Properties
+    
+    private var connectionColor: Color {
+        Color("AsaDarkSlate").opacity(0.7)
+    }
+    
+    private var midPoint: CGPoint {
+        let fromPosition = viewModel.getDisplayPosition(for: fromNode.position)
+        let toPosition = viewModel.getDisplayPosition(for: toNode.position)
+        
+        return CGPoint(
+            x: (fromPosition.x + toPosition.x) / 2,
+            y: (fromPosition.y + toPosition.y) / 2
+        )
+    }
+    
+    // MARK: - Actions
+    
+    private func toggleDeleteButton() {
+        withAnimation(.easeInOut(duration: 0.2)) {
+            showDeleteButton.toggle()
+        }
+        
+        // 3秒後に自動的に非表示
+        if showDeleteButton {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    showDeleteButton = false
+                }
+            }
+        }
+    }
+    
+    private func deleteConnection() {
+        withAnimation(.easeInOut(duration: 0.2)) {
+            viewModel.deleteConnection(withId: connection.id)
+        }
+    }
+}
+
+// MARK: - ConnectionsLayer
+
+struct ConnectionsLayer: View {
+    let viewModel: MindMapViewModel
+    
+    var body: some View {
+        ZStack {
+            ForEach(viewModel.currentConnections) { connection in
+                if let fromNode = getNode(withId: connection.fromNodeId),
+                   let toNode = getNode(withId: connection.toNodeId) {
+                    ConnectionView(
+                        viewModel: viewModel,
+                        connection: connection,
+                        fromNode: fromNode,
+                        toNode: toNode
+                    )
+                }
+            }
+            
+            // 接続中のプレビューライン
+            if viewModel.isConnecting,
+               let fromNodeId = viewModel.connectingFromNodeId,
+               let fromNode = getNode(withId: fromNodeId) {
+                ConnectionPreview(viewModel: viewModel, fromNode: fromNode)
+            }
+        }
+    }
+    
+    private func getNode(withId id: UUID) -> MindMapNode? {
+        viewModel.currentNodes.first { $0.id == id }
+    }
+}
+
+// MARK: - ConnectionPreview
+
+struct ConnectionPreview: View {
+    let viewModel: MindMapViewModel
+    let fromNode: MindMapNode
+    @State private var mousePosition = CGPoint.zero
+    
+    var body: some View {
+        Canvas { context, size in
+            let fromPosition = viewModel.getDisplayPosition(for: fromNode.position)
+            
+            var path = Path()
+            path.move(to: fromPosition)
+            path.addLine(to: mousePosition)
+            
+            context.stroke(
+                path,
+                with: .color(Color.yellow.opacity(0.6)),
+                style: StrokeStyle(lineWidth: 2, lineCap: .round, dash: [5, 3])
+            )
+        }
+        .onContinuousHover { phase in
+            switch phase {
+            case .active(let location):
+                mousePosition = location
+            case .ended:
+                break
+            }
+        }
+        .allowsHitTesting(false)
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    @Previewable @State var viewModel = MindMapViewModel()
+    
+    return ZStack {
+        Color("AsaSoftCream")
+            .ignoresSafeArea()
+        
+        ConnectionsLayer(viewModel: viewModel)
+    }
+}

--- a/Apps/AsaMindMap/AsaMindMap/ContentView.swift
+++ b/Apps/AsaMindMap/AsaMindMap/ContentView.swift
@@ -1,0 +1,418 @@
+import SwiftUI
+
+// MARK: - ContentView
+
+struct ContentView: View {
+    @State private var viewModel = MindMapViewModel()
+    @State private var showNewMindMapSheet = false
+    @State private var showMindMapList = false
+    @State private var showClearAlert = false
+    @State private var showResetViewAlert = false
+    
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 0) {
+                // MARK: - Mind Map Canvas
+                mindMapCanvas
+                
+                // MARK: - Status Bar
+                statusBar
+            }
+            .navigationTitle(currentMindMapTitle)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    mindMapSelectionButton
+                }
+                
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    toolbarMenu
+                }
+            }
+            .alert("マインドマップをクリア", isPresented: $showClearAlert) {
+                Button("キャンセル", role: .cancel) { }
+                Button("クリア", role: .destructive) {
+                    viewModel.clearCurrentMindMap()
+                }
+            } message: {
+                Text("現在のマインドマップのすべてのノードと接続が削除されます。この操作は元に戻せません。")
+            }
+            .alert("ビューをリセット", isPresented: $showResetViewAlert) {
+                Button("キャンセル", role: .cancel) { }
+                Button("リセット") {
+                    viewModel.resetCanvasTransform()
+                }
+            } message: {
+                Text("ズームとパン位置をリセットしますか？")
+            }
+            .sheet(isPresented: $showNewMindMapSheet) {
+                NewMindMapSheet(viewModel: viewModel, isPresented: $showNewMindMapSheet)
+            }
+            .sheet(isPresented: $showMindMapList) {
+                MindMapListSheet(viewModel: viewModel, isPresented: $showMindMapList)
+            }
+            .background(
+                LinearGradient(
+                    colors: [
+                        Color("AsaSoftCream").opacity(0.1),
+                        Color("AsaDarkSlate").opacity(0.05)
+                    ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+            )
+        }
+    }
+    
+    // MARK: - Mind Map Canvas
+    
+    private var mindMapCanvas: some View {
+        MindMapCanvasView(viewModel: viewModel)
+            .onTapGesture {
+                // 接続モードをキャンセル
+                if viewModel.isConnecting {
+                    viewModel.cancelConnection()
+                }
+            }
+    }
+    
+    // MARK: - Status Bar
+    
+    private var statusBar: some View {
+        AsaCard {
+            HStack {
+                // 統計情報
+                statsSection
+                
+                Spacer()
+                
+                // 接続中の表示
+                if viewModel.isConnecting {
+                    connectionStatusView
+                } else {
+                    // キャンバスコントロール
+                    canvasControls
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+        }
+        .background(Color("AsaDarkSlate").opacity(0.05))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+    }
+    
+    // MARK: - Stats Section
+    
+    private var statsSection: some View {
+        HStack(spacing: 16) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("ノード: \(viewModel.currentNodeCount)")
+                    .font(.caption)
+                    .foregroundColor(Color("AsaDarkSlate"))
+                Text("接続: \(viewModel.currentConnectionCount)")
+                    .font(.caption2)
+                    .foregroundColor(Color("AsaMutedSage"))
+            }
+            
+            Text("🧠")
+                .font(.title2)
+        }
+    }
+    
+    // MARK: - Connection Status View
+    
+    private var connectionStatusView: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "link")
+                .foregroundColor(.yellow)
+                .scaleEffect(1.2)
+                .animation(.easeInOut(duration: 0.6).repeatForever(autoreverses: true), value: viewModel.isConnecting)
+            
+            Text("接続先を選択してください")
+                .font(.caption)
+                .foregroundColor(Color("AsaDarkSlate"))
+            
+            AsaButton(
+                title: "キャンセル",
+                action: { viewModel.cancelConnection() },
+                color: Color("AsaMutedSage")
+            )
+            .frame(width: 80, height: 24)
+        }
+    }
+    
+    // MARK: - Canvas Controls
+    
+    private var canvasControls: some View {
+        HStack(spacing: 8) {
+            // ズーム表示
+            Text("×\(String(format: "%.1f", viewModel.canvasScale))")
+                .font(.caption2)
+                .foregroundColor(Color("AsaMutedSage"))
+                .frame(minWidth: 30)
+            
+            Button(action: {
+                showResetViewAlert = true
+            }) {
+                Image(systemName: "arrow.counterclockwise")
+                    .font(.system(size: 14))
+                    .foregroundColor(Color("AsaDarkSlate"))
+            }
+        }
+    }
+    
+    // MARK: - Mind Map Selection Button
+    
+    private var mindMapSelectionButton: some View {
+        Button(action: {
+            showMindMapList = true
+        }) {
+            HStack(spacing: 4) {
+                Image(systemName: "list.bullet")
+                    .font(.system(size: 16))
+                Text("\(viewModel.mindMapCount)")
+                    .font(.caption)
+            }
+            .foregroundColor(Color("AsaCoffeeBrown"))
+        }
+    }
+    
+    // MARK: - Toolbar Menu
+    
+    private var toolbarMenu: some View {
+        Menu {
+            Button(action: {
+                showNewMindMapSheet = true
+            }) {
+                Label("新しいマインドマップ", systemImage: "plus.circle")
+            }
+            
+            Divider()
+            
+            Button(action: {
+                showClearAlert = true
+            }) {
+                Label("現在のマップをクリア", systemImage: "trash")
+            }
+            
+            Button(action: {
+                showResetViewAlert = true
+            }) {
+                Label("ビューをリセット", systemImage: "arrow.counterclockwise")
+            }
+            
+            Divider()
+            
+            Button(action: {}) {
+                Label("使い方", systemImage: "questionmark.circle")
+            }
+            
+        } label: {
+            Image(systemName: "ellipsis.circle")
+                .foregroundColor(Color("AsaCoffeeBrown"))
+        }
+    }
+    
+    // MARK: - Computed Properties
+    
+    private var currentMindMapTitle: String {
+        viewModel.currentMindMap?.title ?? "AsaMindMap"
+    }
+}
+
+// MARK: - NewMindMapSheet
+
+struct NewMindMapSheet: View {
+    @Bindable var viewModel: MindMapViewModel
+    @Binding var isPresented: Bool
+    
+    @State private var title = ""
+    @State private var centralNodeText = ""
+    @FocusState private var isTitleFieldFocused: Bool
+    
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 24) {
+                // ヘッダー
+                VStack(spacing: 8) {
+                    Image(systemName: "brain.head.profile")
+                        .font(.system(size: 50))
+                        .foregroundColor(Color("AsaCoffeeBrown"))
+                    
+                    Text("新しいマインドマップ")
+                        .font(.title2)
+                        .fontWeight(.medium)
+                        .foregroundColor(Color("AsaDarkSlate"))
+                }
+                .padding(.top)
+                
+                // 入力フィールド
+                AsaCard {
+                    VStack(spacing: 16) {
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("タイトル")
+                                .font(.headline)
+                                .foregroundColor(Color("AsaDarkSlate"))
+                            
+                            TextField("マインドマップのタイトル", text: $title)
+                                .textFieldStyle(.roundedBorder)
+                                .focused($isTitleFieldFocused)
+                        }
+                        
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("中心ノード")
+                                .font(.headline)
+                                .foregroundColor(Color("AsaDarkSlate"))
+                            
+                            TextField("中心となるアイデア", text: $centralNodeText)
+                                .textFieldStyle(.roundedBorder)
+                        }
+                    }
+                    .padding()
+                }
+                
+                // アクションボタン
+                HStack(spacing: 16) {
+                    AsaButton(
+                        title: "キャンセル",
+                        action: { isPresented = false },
+                        color: Color("AsaMutedSage")
+                    )
+                    
+                    AsaButton(
+                        title: "作成",
+                        action: createMindMap,
+                        isEnabled: !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                    )
+                }
+                .padding(.horizontal)
+                
+                Spacer()
+            }
+            .padding()
+            .navigationTitle("")
+            .navigationBarTitleDisplayMode(.inline)
+            .onAppear {
+                isTitleFieldFocused = true
+            }
+        }
+        .presentationDetents([.medium])
+        .presentationDragIndicator(.visible)
+    }
+    
+    private func createMindMap() {
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        guard !trimmedTitle.isEmpty else { return }
+        
+        viewModel.createNewMindMap(title: trimmedTitle)
+        
+        isPresented = false
+    }
+}
+
+// MARK: - MindMapListSheet
+
+struct MindMapListSheet: View {
+    @Bindable var viewModel: MindMapViewModel
+    @Binding var isPresented: Bool
+    
+    var body: some View {
+        NavigationView {
+            List {
+                ForEach(viewModel.mindMaps) { mindMap in
+                    MindMapRowView(
+                        mindMap: mindMap,
+                        isSelected: viewModel.currentMindMap?.id == mindMap.id,
+                        onSelect: {
+                            viewModel.selectMindMap(mindMap)
+                            isPresented = false
+                        }
+                    )
+                }
+                .onDelete(perform: deleteMindMaps)
+            }
+            .navigationTitle("マインドマップ一覧")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("完了") {
+                        isPresented = false
+                    }
+                    .foregroundColor(Color("AsaCoffeeBrown"))
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
+    }
+    
+    private func deleteMindMaps(offsets: IndexSet) {
+        for index in offsets {
+            let mindMap = viewModel.mindMaps[index]
+            viewModel.deleteMindMap(withId: mindMap.id)
+        }
+    }
+}
+
+// MARK: - MindMapRowView
+
+struct MindMapRowView: View {
+    let mindMap: MindMap
+    let isSelected: Bool
+    let onSelect: () -> Void
+    
+    var body: some View {
+        Button(action: onSelect) {
+            AsaCard {
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Text(mindMap.title)
+                            .font(.headline)
+                            .foregroundColor(.white)
+                        
+                        Spacer()
+                        
+                        if isSelected {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundColor(.white)
+                        }
+                    }
+                    
+                    HStack {
+                        Text("ノード: \(mindMap.nodeCount)")
+                            .font(.caption)
+                            .foregroundColor(.white.opacity(0.8))
+                        
+                        Text("接続: \(mindMap.connectionCount)")
+                            .font(.caption)
+                            .foregroundColor(.white.opacity(0.8))
+                        
+                        Spacer()
+                        
+                        Text(mindMap.formattedModifiedTime)
+                            .font(.caption2)
+                            .foregroundColor(.white.opacity(0.6))
+                    }
+                }
+                .padding()
+            }
+            .background(
+                RoundedRectangle(cornerRadius: 15)
+                    .fill(isSelected ? Color("AsaCoffeeBrown") : Color("AsaMocha"))
+                    .shadow(radius: isSelected ? 6 : 3)
+            )
+        }
+        .buttonStyle(.plain)
+        .listRowBackground(Color.clear)
+        .listRowSeparator(.hidden)
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    ContentView()
+}

--- a/Apps/AsaMindMap/AsaMindMap/MindMap.swift
+++ b/Apps/AsaMindMap/AsaMindMap/MindMap.swift
@@ -1,0 +1,162 @@
+import Foundation
+import SwiftUI
+
+// MARK: - MindMap Model
+
+struct MindMap: Identifiable, Codable, Equatable {
+    let id = UUID()
+    var title: String
+    var nodes: [MindMapNode]
+    var connections: [MindMapConnection]
+    let createdAt: Date
+    var modifiedAt: Date
+    
+    // MARK: - Initialization
+    
+    init(title: String, nodes: [MindMapNode] = [], connections: [MindMapConnection] = []) {
+        self.title = title
+        self.nodes = nodes
+        self.connections = connections
+        self.createdAt = Date()
+        self.modifiedAt = Date()
+    }
+    
+    // MARK: - Node Management
+    
+    mutating func addNode(_ node: MindMapNode) {
+        nodes.append(node)
+        updateModificationTime()
+    }
+    
+    mutating func removeNode(withId nodeId: UUID) {
+        nodes.removeAll { $0.id == nodeId }
+        connections.removeAll { $0.isConnectedTo(nodeId: nodeId) }
+        updateModificationTime()
+    }
+    
+    mutating func updateNode(withId nodeId: UUID, _ updateClosure: (inout MindMapNode) -> Void) {
+        if let index = nodes.firstIndex(where: { $0.id == nodeId }) {
+            updateClosure(&nodes[index])
+            updateModificationTime()
+        }
+    }
+    
+    func getNode(withId nodeId: UUID) -> MindMapNode? {
+        nodes.first { $0.id == nodeId }
+    }
+    
+    // MARK: - Connection Management
+    
+    mutating func addConnection(_ connection: MindMapConnection) {
+        if !connections.contains(where: { 
+            ($0.fromNodeId == connection.fromNodeId && $0.toNodeId == connection.toNodeId) ||
+            ($0.fromNodeId == connection.toNodeId && $0.toNodeId == connection.fromNodeId)
+        }) {
+            connections.append(connection)
+            updateModificationTime()
+        }
+    }
+    
+    mutating func removeConnection(withId connectionId: UUID) {
+        connections.removeAll { $0.id == connectionId }
+        updateModificationTime()
+    }
+    
+    mutating func connectNodes(fromId: UUID, toId: UUID) {
+        let connection = MindMapConnection.connect(fromId: fromId, toId: toId)
+        addConnection(connection)
+    }
+    
+    func getConnectedNodes(to nodeId: UUID) -> [MindMapNode] {
+        let connectedIds = connections.compactMap { connection in
+            connection.getOtherNodeId(currentNodeId: nodeId)
+        }
+        return nodes.filter { connectedIds.contains($0.id) }
+    }
+    
+    // MARK: - Utility Methods
+    
+    private mutating func updateModificationTime() {
+        modifiedAt = Date()
+    }
+    
+    mutating func updateTitle(_ newTitle: String) {
+        title = newTitle
+        updateModificationTime()
+    }
+    
+    mutating func clearAll() {
+        nodes.removeAll()
+        connections.removeAll()
+        updateModificationTime()
+    }
+    
+    // MARK: - Computed Properties
+    
+    var nodeCount: Int {
+        nodes.count
+    }
+    
+    var connectionCount: Int {
+        connections.count
+    }
+    
+    var isEmpty: Bool {
+        nodes.isEmpty && connections.isEmpty
+    }
+    
+    var formattedCreatedTime: String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter.string(from: createdAt)
+    }
+    
+    var formattedModifiedTime: String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        formatter.timeStyle = .short
+        return formatter.string(from: modifiedAt)
+    }
+    
+    // MARK: - Static Factory Methods
+    
+    static func createEmpty(title: String) -> MindMap {
+        MindMap(title: title)
+    }
+    
+    static func createWithCentralNode(title: String, centralNodeText: String) -> MindMap {
+        let centralNode = MindMapNode.createCentralNode(text: centralNodeText)
+        return MindMap(title: title, nodes: [centralNode])
+    }
+}
+
+// MARK: - MindMap Extensions
+
+extension MindMap {
+    // MARK: - Sample Data for Preview
+    
+    static let sampleMindMap: MindMap = {
+        let centralNode = MindMapNode.createCentralNode(text: "朝活アイデア")
+        
+        let childNodes = [
+            MindMapNode(text: "SwiftUI学習", position: CGPoint(x: 100, y: 200)),
+            MindMapNode(text: "健康管理", position: CGPoint(x: 300, y: 200)),
+            MindMapNode(text: "読書", position: CGPoint(x: 100, y: 400)),
+            MindMapNode(text: "運動", position: CGPoint(x: 300, y: 400))
+        ]
+        
+        let connections = [
+            MindMapConnection.connect(fromId: centralNode.id, toId: childNodes[0].id),
+            MindMapConnection.connect(fromId: centralNode.id, toId: childNodes[1].id),
+            MindMapConnection.connect(fromId: centralNode.id, toId: childNodes[2].id),
+            MindMapConnection.connect(fromId: centralNode.id, toId: childNodes[3].id)
+        ]
+        
+        return MindMap(
+            title: "サンプルマインドマップ",
+            nodes: [centralNode] + childNodes,
+            connections: connections
+        )
+    }()
+}

--- a/Apps/AsaMindMap/AsaMindMap/MindMapCanvasView.swift
+++ b/Apps/AsaMindMap/AsaMindMap/MindMapCanvasView.swift
@@ -1,0 +1,331 @@
+import SwiftUI
+
+// MARK: - MindMapCanvasView
+
+struct MindMapCanvasView: View {
+    @Bindable var viewModel: MindMapViewModel
+    @State private var lastScaleValue: CGFloat = 1.0
+    @State private var lastOffsetValue = CGSize.zero
+    @State private var showAddNodeSheet = false
+    @State private var tapLocation = CGPoint.zero
+    
+    var body: some View {
+        GeometryReader { geometry in
+            ZStack {
+                // 背景
+                canvasBackground
+                    .onTapGesture(count: 2) { location in
+                        handleDoubleTap(at: location, in: geometry)
+                    }
+                    .onTapGesture { _ in
+                        dismissSelection()
+                    }
+                
+                // 接続線レイヤー
+                ConnectionsLayer(viewModel: viewModel)
+                    .allowsHitTesting(!viewModel.isPanGestureActive)
+                
+                // ノードレイヤー
+                nodesLayer
+                    .allowsHitTesting(!viewModel.isPanGestureActive)
+                
+                // マインドマップが空の場合のプレースホルダー
+                if viewModel.currentNodes.isEmpty {
+                    emptyStateView
+                }
+            }
+            .scaleEffect(viewModel.canvasScale)
+            .offset(viewModel.canvasOffset)
+            .gesture(simultaneousGestures)
+            .clipped()
+        }
+        .background(Color("AsaSoftCream").opacity(0.3))
+        .sheet(isPresented: $showAddNodeSheet) {
+            AddNodeSheet(
+                viewModel: viewModel,
+                position: tapLocation,
+                isPresented: $showAddNodeSheet
+            )
+        }
+    }
+    
+    // MARK: - Canvas Background
+    
+    private var canvasBackground: some View {
+        Rectangle()
+            .fill(
+                LinearGradient(
+                    colors: [
+                        Color("AsaSoftCream").opacity(0.1),
+                        Color("AsaDarkSlate").opacity(0.05)
+                    ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+            )
+            .overlay(
+                gridPattern
+                    .opacity(0.2)
+            )
+    }
+    
+    // MARK: - Grid Pattern
+    
+    private var gridPattern: some View {
+        Canvas { context, size in
+            let spacing: CGFloat = 50 * viewModel.canvasScale
+            let offsetX = viewModel.canvasOffset.width.truncatingRemainder(dividingBy: spacing)
+            let offsetY = viewModel.canvasOffset.height.truncatingRemainder(dividingBy: spacing)
+            
+            // 垂直線
+            var x = offsetX
+            while x < size.width {
+                var path = Path()
+                path.move(to: CGPoint(x: x, y: 0))
+                path.addLine(to: CGPoint(x: x, y: size.height))
+                context.stroke(path, with: .color(Color("AsaMutedSage").opacity(0.3)), lineWidth: 1)
+                x += spacing
+            }
+            
+            // 水平線
+            var y = offsetY
+            while y < size.height {
+                var path = Path()
+                path.move(to: CGPoint(x: 0, y: y))
+                path.addLine(to: CGPoint(x: size.width, y: y))
+                context.stroke(path, with: .color(Color("AsaMutedSage").opacity(0.3)), lineWidth: 1)
+                y += spacing
+            }
+        }
+    }
+    
+    // MARK: - Nodes Layer
+    
+    private var nodesLayer: some View {
+        ZStack {
+            ForEach(viewModel.currentNodes) { node in
+                NodeView(viewModel: viewModel, node: node)
+            }
+        }
+    }
+    
+    // MARK: - Empty State View
+    
+    private var emptyStateView: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "brain.head.profile")
+                .font(.system(size: 60))
+                .foregroundColor(Color("AsaMutedSage"))
+            
+            VStack(spacing: 8) {
+                Text("マインドマップを作成しましょう")
+                    .font(.title2)
+                    .fontWeight(.medium)
+                    .foregroundColor(Color("AsaDarkSlate"))
+                
+                Text("画面をダブルタップしてノードを追加")
+                    .font(.body)
+                    .foregroundColor(Color("AsaMutedSage"))
+            }
+            
+            AsaButton(
+                title: "ノードを追加",
+                action: {
+                    handleDoubleTap(at: CGPoint(x: 200, y: 300), in: nil)
+                }
+            )
+            .frame(width: 150)
+        }
+        .animation(.easeInOut(duration: 0.5), value: viewModel.currentNodes.isEmpty)
+    }
+    
+    // MARK: - Gestures
+    
+    private var simultaneousGestures: some Gesture {
+        SimultaneousGesture(
+            panGesture,
+            magnificationGesture
+        )
+    }
+    
+    private var panGesture: some Gesture {
+        DragGesture()
+            .onChanged { value in
+                viewModel.isPanGestureActive = true
+                let newOffset = CGSize(
+                    width: lastOffsetValue.width + value.translation.width,
+                    height: lastOffsetValue.height + value.translation.height
+                )
+                viewModel.updateCanvasTransform(offset: newOffset, scale: viewModel.canvasScale)
+            }
+            .onEnded { _ in
+                lastOffsetValue = viewModel.canvasOffset
+                
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    viewModel.isPanGestureActive = false
+                }
+            }
+    }
+    
+    private var magnificationGesture: some Gesture {
+        MagnificationGesture()
+            .onChanged { value in
+                let newScale = lastScaleValue * value
+                viewModel.updateCanvasTransform(offset: viewModel.canvasOffset, scale: newScale)
+            }
+            .onEnded { _ in
+                lastScaleValue = viewModel.canvasScale
+            }
+    }
+    
+    // MARK: - Actions
+    
+    private func handleDoubleTap(at location: CGPoint, in geometry: GeometryProxy?) {
+        let canvasLocation = geometry?.frame(in: .local).contains(location) == true ? location : CGPoint(x: 200, y: 300)
+        tapLocation = canvasLocation
+        showAddNodeSheet = true
+    }
+    
+    private func dismissSelection() {
+        viewModel.selectedNodeId = nil
+        if viewModel.isConnecting {
+            viewModel.cancelConnection()
+        }
+    }
+}
+
+// MARK: - AddNodeSheet
+
+struct AddNodeSheet: View {
+    @Bindable var viewModel: MindMapViewModel
+    let position: CGPoint
+    @Binding var isPresented: Bool
+    
+    @State private var nodeText = ""
+    @State private var selectedColor: NodeColor = .asaCoffeeBrown
+    @FocusState private var isTextFieldFocused: Bool
+    
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 24) {
+                // ヘッダー
+                VStack(spacing: 8) {
+                    Image(systemName: "plus.circle.fill")
+                        .font(.system(size: 40))
+                        .foregroundColor(selectedColor.color)
+                    
+                    Text("新しいノードを追加")
+                        .font(.title2)
+                        .fontWeight(.medium)
+                        .foregroundColor(Color("AsaDarkSlate"))
+                }
+                .padding(.top)
+                
+                // テキスト入力
+                AsaCard {
+                    VStack(spacing: 16) {
+                        TextField("ノードのテキストを入力...", text: $nodeText, axis: .vertical)
+                            .textFieldStyle(.plain)
+                            .font(.body)
+                            .focused($isTextFieldFocused)
+                            .lineLimit(1...5)
+                            .onSubmit {
+                                addNode()
+                            }
+                        
+                        // カラー選択
+                        colorSelectionView
+                    }
+                    .padding()
+                }
+                
+                // アクションボタン
+                HStack(spacing: 16) {
+                    AsaButton(
+                        title: "キャンセル",
+                        action: { isPresented = false },
+                        color: Color("AsaMutedSage")
+                    )
+                    
+                    AsaButton(
+                        title: "追加",
+                        action: addNode,
+                        isEnabled: !nodeText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                    )
+                }
+                .padding(.horizontal)
+                
+                Spacer()
+            }
+            .padding()
+            .navigationTitle("")
+            .navigationBarTitleDisplayMode(.inline)
+            .onAppear {
+                isTextFieldFocused = true
+            }
+        }
+        .presentationDetents([.medium])
+        .presentationDragIndicator(.visible)
+    }
+    
+    // MARK: - Color Selection View
+    
+    private var colorSelectionView: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("カラー")
+                .font(.headline)
+                .foregroundColor(Color("AsaDarkSlate"))
+            
+            LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 8), count: 5), spacing: 12) {
+                ForEach(NodeColor.allCases, id: \.self) { color in
+                    Button(action: {
+                        selectedColor = color
+                    }) {
+                        Circle()
+                            .fill(color.color)
+                            .frame(width: 40, height: 40)
+                            .overlay(
+                                Circle()
+                                    .stroke(
+                                        Color.white,
+                                        lineWidth: selectedColor == color ? 3 : 0
+                                    )
+                            )
+                            .scaleEffect(selectedColor == color ? 1.1 : 1.0)
+                            .shadow(radius: selectedColor == color ? 4 : 2)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+    
+    // MARK: - Actions
+    
+    private func addNode() {
+        let trimmedText = nodeText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedText.isEmpty else { return }
+        
+        let adjustedPosition = CGPoint(
+            x: (position.x - viewModel.canvasOffset.width) / viewModel.canvasScale,
+            y: (position.y - viewModel.canvasOffset.height) / viewModel.canvasScale
+        )
+        
+        viewModel.addNode(text: trimmedText, position: adjustedPosition)
+        
+        // カラーを更新（ノードが作成された後）
+        if let lastNode = viewModel.currentNodes.last {
+            viewModel.updateNodeColor(nodeId: lastNode.id, color: selectedColor)
+        }
+        
+        isPresented = false
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    @Previewable @State var viewModel = MindMapViewModel()
+    
+    return MindMapCanvasView(viewModel: viewModel)
+}

--- a/Apps/AsaMindMap/AsaMindMap/MindMapConnection.swift
+++ b/Apps/AsaMindMap/AsaMindMap/MindMapConnection.swift
@@ -1,0 +1,94 @@
+import Foundation
+import SwiftUI
+
+// MARK: - MindMapConnection Model
+
+struct MindMapConnection: Identifiable, Codable, Equatable {
+    let id = UUID()
+    let fromNodeId: UUID
+    let toNodeId: UUID
+    var lineStyle: LineStyle
+    var createdAt: Date
+    
+    // MARK: - Initialization
+    
+    init(fromNodeId: UUID, toNodeId: UUID, lineStyle: LineStyle = .solid) {
+        self.fromNodeId = fromNodeId
+        self.toNodeId = toNodeId
+        self.lineStyle = lineStyle
+        self.createdAt = Date()
+    }
+    
+    // MARK: - Helper Methods
+    
+    func isConnectedTo(nodeId: UUID) -> Bool {
+        fromNodeId == nodeId || toNodeId == nodeId
+    }
+    
+    func getOtherNodeId(currentNodeId: UUID) -> UUID? {
+        if fromNodeId == currentNodeId {
+            return toNodeId
+        } else if toNodeId == currentNodeId {
+            return fromNodeId
+        }
+        return nil
+    }
+    
+    // MARK: - Static Factory Methods
+    
+    static func connect(from: MindMapNode, to: MindMapNode) -> MindMapConnection {
+        MindMapConnection(fromNodeId: from.id, toNodeId: to.id)
+    }
+    
+    static func connect(fromId: UUID, toId: UUID, style: LineStyle = .solid) -> MindMapConnection {
+        MindMapConnection(fromNodeId: fromId, toNodeId: toId, lineStyle: style)
+    }
+}
+
+// MARK: - LineStyle Enum
+
+enum LineStyle: String, CaseIterable, Codable {
+    case solid = "solid"
+    case dashed = "dashed"
+    case dotted = "dotted"
+    
+    var displayName: String {
+        switch self {
+        case .solid:
+            return "実線"
+        case .dashed:
+            return "破線"
+        case .dotted:
+            return "点線"
+        }
+    }
+    
+    var strokeStyle: StrokeStyle {
+        switch self {
+        case .solid:
+            return StrokeStyle(lineWidth: 2, lineCap: .round)
+        case .dashed:
+            return StrokeStyle(lineWidth: 2, lineCap: .round, dash: [8, 4])
+        case .dotted:
+            return StrokeStyle(lineWidth: 2, lineCap: .round, dash: [2, 4])
+        }
+    }
+}
+
+// MARK: - MindMapConnection Extensions
+
+extension MindMapConnection {
+    var formattedCreatedTime: String {
+        let formatter = DateFormatter()
+        formatter.timeStyle = .short
+        return formatter.string(from: createdAt)
+    }
+    
+    // MARK: - Sample Data for Preview
+    
+    static let sampleConnections: [MindMapConnection] = [
+        MindMapConnection(fromNodeId: UUID(), toNodeId: UUID()),
+        MindMapConnection(fromNodeId: UUID(), toNodeId: UUID(), lineStyle: .dashed),
+        MindMapConnection(fromNodeId: UUID(), toNodeId: UUID(), lineStyle: .dotted)
+    ]
+}

--- a/Apps/AsaMindMap/AsaMindMap/MindMapNode.swift
+++ b/Apps/AsaMindMap/AsaMindMap/MindMapNode.swift
@@ -1,0 +1,112 @@
+import Foundation
+import SwiftUI
+
+// MARK: - MindMapNode Model
+
+struct MindMapNode: Identifiable, Codable, Equatable {
+    let id = UUID()
+    var text: String
+    var position: CGPoint
+    var color: NodeColor
+    var isEditing: Bool = false
+    var createdAt: Date
+    var modifiedAt: Date
+    
+    // MARK: - Initialization
+    
+    init(text: String, position: CGPoint = CGPoint(x: 200, y: 200), color: NodeColor = .asaCoffeeBrown) {
+        self.text = text
+        self.position = position
+        self.color = color
+        self.createdAt = Date()
+        self.modifiedAt = Date()
+    }
+    
+    // MARK: - Mutating Methods
+    
+    mutating func updateText(_ newText: String) {
+        text = newText
+        modifiedAt = Date()
+    }
+    
+    mutating func updatePosition(_ newPosition: CGPoint) {
+        position = newPosition
+        modifiedAt = Date()
+    }
+    
+    mutating func updateColor(_ newColor: NodeColor) {
+        color = newColor
+        modifiedAt = Date()
+    }
+    
+    mutating func toggleEditing() {
+        isEditing.toggle()
+    }
+    
+    // MARK: - Static Factory Methods
+    
+    static func createNode(text: String, position: CGPoint) -> MindMapNode {
+        MindMapNode(text: text, position: position)
+    }
+    
+    static func createCentralNode(text: String) -> MindMapNode {
+        MindMapNode(text: text, position: CGPoint(x: 200, y: 300), color: .asaMocha)
+    }
+}
+
+// MARK: - NodeColor Enum
+
+enum NodeColor: String, CaseIterable, Codable {
+    case asaCoffeeBrown = "AsaCoffeeBrown"
+    case asaMocha = "AsaMocha"
+    case asaSoftCream = "AsaSoftCream"
+    case asaDarkSlate = "AsaDarkSlate"
+    case asaMutedSage = "AsaMutedSage"
+    
+    var color: Color {
+        Color(self.rawValue)
+    }
+    
+    var displayName: String {
+        switch self {
+        case .asaCoffeeBrown:
+            return "コーヒーブラウン"
+        case .asaMocha:
+            return "モカ"
+        case .asaSoftCream:
+            return "ソフトクリーム"
+        case .asaDarkSlate:
+            return "ダークスレート"
+        case .asaMutedSage:
+            return "ミューテッドセージ"
+        }
+    }
+}
+
+// MARK: - MindMapNode Extensions
+
+extension MindMapNode {
+    var formattedCreatedTime: String {
+        let formatter = DateFormatter()
+        formatter.timeStyle = .short
+        formatter.dateStyle = .short
+        return formatter.string(from: createdAt)
+    }
+    
+    var isEmpty: Bool {
+        text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+    
+    var displayText: String {
+        text.isEmpty ? "新しいノード" : text
+    }
+    
+    // MARK: - Sample Data for Preview
+    
+    static let sampleNodes: [MindMapNode] = [
+        MindMapNode(text: "朝活アイデア", position: CGPoint(x: 200, y: 150)),
+        MindMapNode(text: "SwiftUI学習", position: CGPoint(x: 100, y: 250)),
+        MindMapNode(text: "健康管理", position: CGPoint(x: 300, y: 250)),
+        MindMapNode(text: "アプリ開発", position: CGPoint(x: 50, y: 350))
+    ]
+}

--- a/Apps/AsaMindMap/AsaMindMap/MindMapViewModel.swift
+++ b/Apps/AsaMindMap/AsaMindMap/MindMapViewModel.swift
@@ -1,0 +1,277 @@
+import Foundation
+import SwiftUI
+import Observation
+
+// MARK: - MindMapViewModel
+
+@Observable
+class MindMapViewModel {
+    
+    // MARK: - Properties
+    
+    private(set) var mindMaps: [MindMap] = []
+    private(set) var currentMindMap: MindMap?
+    var isEditing = false
+    var selectedNodeId: UUID?
+    var connectingFromNodeId: UUID?
+    var canvasOffset = CGSize.zero
+    var canvasScale: CGFloat = 1.0
+    
+    // 新規ノード作成時のテキスト
+    var newNodeText = ""
+    
+    // パン操作の状態
+    var isPanGestureActive = false
+    
+    private let mindMapsKey = "AsaMindMap_MindMaps"
+    private let currentMindMapKey = "AsaMindMap_CurrentMindMapId"
+    
+    // MARK: - Initialization
+    
+    init() {
+        loadMindMaps()
+        
+        // 初回起動時にサンプルマインドマップを作成
+        if mindMaps.isEmpty {
+            createSampleMindMap()
+        }
+        
+        // 前回開いていたマインドマップを復元
+        loadCurrentMindMap()
+    }
+    
+    // MARK: - MindMap Management
+    
+    func createNewMindMap(title: String) {
+        let newMindMap = MindMap.createWithCentralNode(title: title, centralNodeText: title)
+        mindMaps.append(newMindMap)
+        currentMindMap = newMindMap
+        saveMindMaps()
+        saveCurrentMindMapId()
+    }
+    
+    func selectMindMap(_ mindMap: MindMap) {
+        currentMindMap = mindMap
+        resetCanvasTransform()
+        saveCurrentMindMapId()
+    }
+    
+    func deleteMindMap(withId mindMapId: UUID) {
+        mindMaps.removeAll { $0.id == mindMapId }
+        if currentMindMap?.id == mindMapId {
+            currentMindMap = mindMaps.first
+        }
+        saveMindMaps()
+        saveCurrentMindMapId()
+    }
+    
+    func updateCurrentMindMapTitle(_ newTitle: String) {
+        guard var mindMap = currentMindMap else { return }
+        mindMap.updateTitle(newTitle)
+        updateCurrentMindMap(mindMap)
+    }
+    
+    // MARK: - Node Management
+    
+    func addNode(text: String, position: CGPoint) {
+        guard var mindMap = currentMindMap else { return }
+        let adjustedPosition = adjustPositionForCanvas(position)
+        let newNode = MindMapNode.createNode(text: text, position: adjustedPosition)
+        mindMap.addNode(newNode)
+        updateCurrentMindMap(mindMap)
+    }
+    
+    func updateNodeText(nodeId: UUID, text: String) {
+        guard var mindMap = currentMindMap else { return }
+        mindMap.updateNode(withId: nodeId) { node in
+            node.updateText(text)
+        }
+        updateCurrentMindMap(mindMap)
+    }
+    
+    func updateNodePosition(nodeId: UUID, position: CGPoint) {
+        guard var mindMap = currentMindMap else { return }
+        let adjustedPosition = adjustPositionForCanvas(position)
+        mindMap.updateNode(withId: nodeId) { node in
+            node.updatePosition(adjustedPosition)
+        }
+        updateCurrentMindMap(mindMap)
+    }
+    
+    func updateNodeColor(nodeId: UUID, color: NodeColor) {
+        guard var mindMap = currentMindMap else { return }
+        mindMap.updateNode(withId: nodeId) { node in
+            node.updateColor(color)
+        }
+        updateCurrentMindMap(mindMap)
+    }
+    
+    func deleteNode(withId nodeId: UUID) {
+        guard var mindMap = currentMindMap else { return }
+        mindMap.removeNode(withId: nodeId)
+        
+        if selectedNodeId == nodeId {
+            selectedNodeId = nil
+        }
+        if connectingFromNodeId == nodeId {
+            connectingFromNodeId = nil
+        }
+        
+        updateCurrentMindMap(mindMap)
+    }
+    
+    func toggleNodeEditing(nodeId: UUID) {
+        guard var mindMap = currentMindMap else { return }
+        mindMap.updateNode(withId: nodeId) { node in
+            node.toggleEditing()
+        }
+        updateCurrentMindMap(mindMap)
+    }
+    
+    // MARK: - Connection Management
+    
+    func startConnecting(fromNodeId: UUID) {
+        connectingFromNodeId = fromNodeId
+    }
+    
+    func completeConnection(toNodeId: UUID) {
+        guard let fromNodeId = connectingFromNodeId,
+              var mindMap = currentMindMap,
+              fromNodeId != toNodeId else {
+            connectingFromNodeId = nil
+            return
+        }
+        
+        mindMap.connectNodes(fromId: fromNodeId, toId: toNodeId)
+        updateCurrentMindMap(mindMap)
+        connectingFromNodeId = nil
+    }
+    
+    func cancelConnection() {
+        connectingFromNodeId = nil
+    }
+    
+    func deleteConnection(withId connectionId: UUID) {
+        guard var mindMap = currentMindMap else { return }
+        mindMap.removeConnection(withId: connectionId)
+        updateCurrentMindMap(mindMap)
+    }
+    
+    // MARK: - Canvas Management
+    
+    func updateCanvasTransform(offset: CGSize, scale: CGFloat) {
+        canvasOffset = offset
+        canvasScale = max(0.5, min(3.0, scale)) // スケール制限
+    }
+    
+    func resetCanvasTransform() {
+        canvasOffset = .zero
+        canvasScale = 1.0
+    }
+    
+    private func adjustPositionForCanvas(_ position: CGPoint) -> CGPoint {
+        CGPoint(
+            x: (position.x - canvasOffset.width) / canvasScale,
+            y: (position.y - canvasOffset.height) / canvasScale
+        )
+    }
+    
+    func getDisplayPosition(for position: CGPoint) -> CGPoint {
+        CGPoint(
+            x: position.x * canvasScale + canvasOffset.width,
+            y: position.y * canvasScale + canvasOffset.height
+        )
+    }
+    
+    // MARK: - Helper Methods
+    
+    private func updateCurrentMindMap(_ mindMap: MindMap) {
+        currentMindMap = mindMap
+        
+        // mindMaps配列も更新
+        if let index = mindMaps.firstIndex(where: { $0.id == mindMap.id }) {
+            mindMaps[index] = mindMap
+        }
+        
+        saveMindMaps()
+    }
+    
+    func clearCurrentMindMap() {
+        guard var mindMap = currentMindMap else { return }
+        mindMap.clearAll()
+        updateCurrentMindMap(mindMap)
+        resetCanvasTransform()
+    }
+    
+    // MARK: - Computed Properties
+    
+    var currentNodes: [MindMapNode] {
+        currentMindMap?.nodes ?? []
+    }
+    
+    var currentConnections: [MindMapConnection] {
+        currentMindMap?.connections ?? []
+    }
+    
+    var isConnecting: Bool {
+        connectingFromNodeId != nil
+    }
+    
+    var mindMapCount: Int {
+        mindMaps.count
+    }
+    
+    var currentNodeCount: Int {
+        currentMindMap?.nodeCount ?? 0
+    }
+    
+    var currentConnectionCount: Int {
+        currentMindMap?.connectionCount ?? 0
+    }
+    
+    // MARK: - Persistence
+    
+    private func saveMindMaps() {
+        do {
+            let data = try JSONEncoder().encode(mindMaps)
+            UserDefaults.standard.set(data, forKey: mindMapsKey)
+        } catch {
+            print("マインドマップの保存に失敗しました: \(error)")
+        }
+    }
+    
+    private func loadMindMaps() {
+        guard let data = UserDefaults.standard.data(forKey: mindMapsKey) else { return }
+        
+        do {
+            mindMaps = try JSONDecoder().decode([MindMap].self, from: data)
+        } catch {
+            print("マインドマップの読み込みに失敗しました: \(error)")
+            mindMaps = []
+        }
+    }
+    
+    private func saveCurrentMindMapId() {
+        if let currentId = currentMindMap?.id.uuidString {
+            UserDefaults.standard.set(currentId, forKey: currentMindMapKey)
+        }
+    }
+    
+    private func loadCurrentMindMap() {
+        guard let currentIdString = UserDefaults.standard.string(forKey: currentMindMapKey),
+              let currentId = UUID(uuidString: currentIdString) else {
+            currentMindMap = mindMaps.first
+            return
+        }
+        
+        currentMindMap = mindMaps.first { $0.id == currentId } ?? mindMaps.first
+    }
+    
+    private func createSampleMindMap() {
+        let sampleMindMap = MindMap.sampleMindMap
+        mindMaps.append(sampleMindMap)
+        currentMindMap = sampleMindMap
+        saveMindMaps()
+        saveCurrentMindMapId()
+    }
+}

--- a/Apps/AsaMindMap/AsaMindMap/NodeView.swift
+++ b/Apps/AsaMindMap/AsaMindMap/NodeView.swift
@@ -1,0 +1,287 @@
+import SwiftUI
+
+// MARK: - NodeView
+
+struct NodeView: View {
+    @Bindable var viewModel: MindMapViewModel
+    let node: MindMapNode
+    @State private var dragOffset = CGSize.zero
+    @State private var editingText = ""
+    @FocusState private var isTextFieldFocused: Bool
+    
+    var body: some View {
+        nodeContent
+            .position(nodePosition)
+            .scaleEffect(viewModel.canvasScale)
+            .gesture(
+                DragGesture()
+                    .onChanged { value in
+                        if !viewModel.isPanGestureActive {
+                            dragOffset = value.translation
+                        }
+                    }
+                    .onEnded { value in
+                        if !viewModel.isPanGestureActive {
+                            let newPosition = CGPoint(
+                                x: node.position.x + value.translation.width / viewModel.canvasScale,
+                                y: node.position.y + value.translation.height / viewModel.canvasScale
+                            )
+                            viewModel.updateNodePosition(nodeId: node.id, position: newPosition)
+                            dragOffset = .zero
+                        }
+                    }
+            )
+            .animation(.easeInOut(duration: 0.2), value: dragOffset)
+            .animation(.easeInOut(duration: 0.2), value: viewModel.selectedNodeId == node.id)
+    }
+    
+    // MARK: - Node Content
+    
+    private var nodeContent: some View {
+        Group {
+            if node.isEditing {
+                editingView
+            } else {
+                displayView
+            }
+        }
+        .offset(dragOffset)
+    }
+    
+    // MARK: - Display View
+    
+    private var displayView: some View {
+        AsaCard {
+            VStack(spacing: 8) {
+                Text(node.displayText)
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundColor(.white)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(3)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                
+                if isSelected {
+                    nodeActionButtons
+                }
+            }
+        }
+        .background(
+            RoundedRectangle(cornerRadius: 15)
+                .fill(node.color.color)
+                .shadow(
+                    color: node.color.color.opacity(0.3),
+                    radius: isSelected ? 8 : 4,
+                    x: 0,
+                    y: 2
+                )
+        )
+        .scaleEffect(isSelected ? 1.05 : 1.0)
+        .overlay(
+            RoundedRectangle(cornerRadius: 15)
+                .stroke(
+                    Color.white.opacity(isSelected ? 0.8 : 0.0),
+                    lineWidth: 2
+                )
+        )
+        .overlay(
+            connectionIndicator,
+            alignment: .topTrailing
+        )
+        .onTapGesture {
+            handleTap()
+        }
+        .onLongPressGesture {
+            handleLongPress()
+        }
+    }
+    
+    // MARK: - Editing View
+    
+    private var editingView: some View {
+        AsaCard {
+            VStack(spacing: 12) {
+                TextField("ノードテキスト", text: $editingText)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundColor(.white)
+                    .multilineTextAlignment(.center)
+                    .focused($isTextFieldFocused)
+                    .onSubmit {
+                        finishEditing()
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                
+                HStack(spacing: 12) {
+                    AsaButton(
+                        title: "完了",
+                        action: finishEditing,
+                        color: Color("AsaMutedSage")
+                    )
+                    .frame(width: 60, height: 32)
+                    
+                    AsaButton(
+                        title: "削除",
+                        action: deleteNode,
+                        color: Color.red
+                    )
+                    .frame(width: 60, height: 32)
+                }
+                .font(.system(size: 12))
+            }
+            .padding(8)
+        }
+        .background(
+            RoundedRectangle(cornerRadius: 15)
+                .fill(node.color.color)
+                .shadow(color: Color.black.opacity(0.2), radius: 8, x: 0, y: 4)
+        )
+        .onAppear {
+            editingText = node.text
+            isTextFieldFocused = true
+        }
+    }
+    
+    // MARK: - Node Action Buttons
+    
+    private var nodeActionButtons: some View {
+        HStack(spacing: 8) {
+            Button(action: {
+                viewModel.toggleNodeEditing(nodeId: node.id)
+            }) {
+                Image(systemName: "pencil")
+                    .font(.system(size: 12))
+                    .foregroundColor(.white)
+                    .padding(4)
+                    .background(Circle().fill(Color.white.opacity(0.2)))
+            }
+            
+            Button(action: {
+                startConnection()
+            }) {
+                Image(systemName: "link")
+                    .font(.system(size: 12))
+                    .foregroundColor(.white)
+                    .padding(4)
+                    .background(Circle().fill(Color.white.opacity(0.2)))
+            }
+            
+            colorPicker
+        }
+    }
+    
+    // MARK: - Color Picker
+    
+    private var colorPicker: some View {
+        Menu {
+            ForEach(NodeColor.allCases, id: \.self) { color in
+                Button(action: {
+                    viewModel.updateNodeColor(nodeId: node.id, color: color)
+                }) {
+                    HStack {
+                        Circle()
+                            .fill(color.color)
+                            .frame(width: 16, height: 16)
+                        Text(color.displayName)
+                        if node.color == color {
+                            Spacer()
+                            Image(systemName: "checkmark")
+                        }
+                    }
+                }
+            }
+        } label: {
+            Image(systemName: "paintbrush")
+                .font(.system(size: 12))
+                .foregroundColor(.white)
+                .padding(4)
+                .background(Circle().fill(Color.white.opacity(0.2)))
+        }
+    }
+    
+    // MARK: - Connection Indicator
+    
+    private var connectionIndicator: some View {
+        Group {
+            if viewModel.connectingFromNodeId == node.id {
+                Circle()
+                    .fill(Color.yellow)
+                    .frame(width: 12, height: 12)
+                    .offset(x: 4, y: -4)
+                    .scaleEffect(viewModel.isConnecting ? 1.2 : 1.0)
+                    .animation(.easeInOut(duration: 0.6).repeatForever(autoreverses: true), value: viewModel.isConnecting)
+            } else if viewModel.isConnecting && viewModel.connectingFromNodeId != node.id {
+                Circle()
+                    .fill(Color.green.opacity(0.7))
+                    .frame(width: 10, height: 10)
+                    .offset(x: 4, y: -4)
+            }
+        }
+    }
+    
+    // MARK: - Computed Properties
+    
+    private var isSelected: Bool {
+        viewModel.selectedNodeId == node.id
+    }
+    
+    private var nodePosition: CGPoint {
+        CGPoint(
+            x: node.position.x + viewModel.canvasOffset.width,
+            y: node.position.y + viewModel.canvasOffset.height
+        )
+    }
+    
+    // MARK: - Actions
+    
+    private func handleTap() {
+        if viewModel.isConnecting && viewModel.connectingFromNodeId != node.id {
+            viewModel.completeConnection(toNodeId: node.id)
+        } else {
+            viewModel.selectedNodeId = (viewModel.selectedNodeId == node.id) ? nil : node.id
+        }
+    }
+    
+    private func handleLongPress() {
+        if !viewModel.isConnecting {
+            startConnection()
+        }
+    }
+    
+    private func startConnection() {
+        if viewModel.isConnecting {
+            viewModel.cancelConnection()
+        } else {
+            viewModel.startConnecting(fromNodeId: node.id)
+        }
+    }
+    
+    private func finishEditing() {
+        let trimmedText = editingText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedText.isEmpty {
+            viewModel.updateNodeText(nodeId: node.id, text: trimmedText)
+        }
+        viewModel.toggleNodeEditing(nodeId: node.id)
+        isTextFieldFocused = false
+    }
+    
+    private func deleteNode() {
+        viewModel.deleteNode(withId: node.id)
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    @Previewable @State var viewModel = MindMapViewModel()
+    
+    return ZStack {
+        Color("AsaSoftCream")
+            .ignoresSafeArea()
+        
+        if let sampleNode = MindMapNode.sampleNodes.first {
+            NodeView(viewModel: viewModel, node: sampleNode)
+        }
+    }
+}

--- a/Apps/AsaMindMap/project.yml
+++ b/Apps/AsaMindMap/project.yml
@@ -1,0 +1,56 @@
+name: AsaMindMap
+options:
+  bundleIdPrefix: com.asapapa.apps
+  deploymentTarget:
+    iOS: "17.0"
+  createIntermediateGroups: true
+  generateEmptyDirectories: true
+
+settings:
+  MARKETING_VERSION: "1.0"
+  CURRENT_PROJECT_VERSION: "1"
+  DEVELOPMENT_TEAM: ""
+  CODE_SIGN_STYLE: Automatic
+  CODE_SIGNING_ALLOWED: NO
+
+targets:
+  AsaMindMap:
+    type: application
+    platform: iOS
+    sources: 
+      - AsaMindMap
+      - ../../Shared
+    resources:
+      - AsaMindMap/Assets.xcassets
+      - ../../Shared/Assets.xcassets
+    settings:
+      PRODUCT_BUNDLE_IDENTIFIER: com.asapapa.apps.asamindmap
+      GENERATE_INFOPLIST_FILE: YES
+      INFOPLIST_KEY_UIApplicationSceneManifest_Generation: true
+      INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents: true
+      INFOPLIST_KEY_UILaunchScreen_Generation: true
+      INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone: "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
+      INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad: "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
+    dependencies:
+      - sdk: SwiftUI.framework
+      - sdk: Foundation.framework
+
+  AsaMindMapTests:
+    type: bundle.unit-test
+    platform: iOS
+    sources: AsaMindMapTests
+    settings:
+      PRODUCT_BUNDLE_IDENTIFIER: com.asapapa.apps.asamindmap.tests
+      GENERATE_INFOPLIST_FILE: YES
+    dependencies:
+      - target: AsaMindMap
+
+  AsaMindMapUITests:
+    type: bundle.ui-testing
+    platform: iOS
+    sources: AsaMindMapUITests
+    settings:
+      PRODUCT_BUNDLE_IDENTIFIER: com.asapapa.apps.asamindmap.ui-tests
+      GENERATE_INFOPLIST_FILE: YES
+    dependencies:
+      - target: AsaMindMap


### PR DESCRIPTION
## Summary
- 新しいマインドマップ作成アプリAsaMindMapを実装
- インタラクティブなノード操作とCanvas APIによる滑らかな接続線描画
- @ObservableマクロとModern SwiftUIアーキテクチャを採用

## 主な機能
- ✨ マインドマップの作成・編集・削除
- 🎯 ドラッグ可能なインタラクティブノード  
- 🎨 Canvas APIによるベジェ曲線接続線
- 🔍 ズーム・パン対応キャンバス
- 💾 UserDefaultsによる永続化
- 🎨 AsaAppsブランド統一コンポーネント

## 技術実装
- **アーキテクチャ**: MVVM + @Observable/@Bindable
- **UI Framework**: SwiftUI (iOS 17+対応)  
- **描画エンジン**: Canvas API
- **プロジェクト管理**: xcodegen
- **永続化**: UserDefaults + JSON

## Test plan
- [x] xcodegenでXcodeプロジェクト生成確認
- [x] iOS Simulatorでのビルド成功確認
- [x] 共有コンポーネント（AsaButton/AsaCard）統合確認
- [x] ブランドカラー統一確認

🤖 Generated with [Claude Code](https://claude.ai/code)